### PR TITLE
Revamp: coordinator pattern, typed state enums, solid MAC validation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:developers.home-assistant.io)",
+      "WebFetch(domain:aarongodfrey.dev)",
+      "Bash(curl:*)",
+      "Bash(find:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
+    ]
+  }
+}

--- a/custom_components/crow_shepherd/__init__.py
+++ b/custom_components/crow_shepherd/__init__.py
@@ -1,85 +1,192 @@
 """The Crow Shepherd integration."""
 from __future__ import annotations
 
+import asyncio
 import logging
 
-import crow_security_ng as crow
-from crow_security_ng import ResponseError
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv
 
-from .const import CONF_PANEL_MAC, DATA_HUB, DOMAIN
+from .const import (
+    CONF_PANEL_CODE,
+    CONF_SCAN_INTERVAL,
+    DATA_COORDINATOR,
+    DATA_HUB,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    PLATFORMS,
+)
+from .coordinator import CrowShepherdCoordinator
 from .hub import CrowHub
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [
-    Platform.ALARM_CONTROL_PANEL,
-    Platform.BINARY_SENSOR,
-    Platform.SWITCH,
-    Platform.SENSOR,
-]
+_WS_RECONNECT_DELAY = 30  # seconds between WebSocket reconnect attempts
+
+BYPASS_ZONE_SCHEMA = vol.Schema(
+    {
+        vol.Required("zone_id"): vol.All(vol.Coerce(int), vol.Range(min=1)),
+        vol.Required("bypass"): cv.boolean,
+    }
+)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Crow Shepherd from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    # Create the hub
-    hub = CrowHub(entry.data, hass)
+    # Build and connect the hub (raises ConfigEntryAuthFailed / ConfigEntryNotReady)
+    hub = CrowHub.from_config_entry(entry.data, entry.options)
+    await hub.async_connect()
 
-    try:
-        # Initialize the panel connection
-        await hub.init_panel()
-    except ResponseError as err:
-        _LOGGER.error("Crow API error: %s - %s", err.status_code, err)
-        if err.status_code == 401 or err.status_code == 403:
-            raise ConfigEntryAuthFailed(
-                "Authentication failed. Please reconfigure the integration."
-            ) from err
-        raise ConfigEntryNotReady(f"Failed to connect: {err}") from err
-    except Exception as err:
-        _LOGGER.error("Unexpected error connecting to Crow Cloud: %s", err)
-        raise ConfigEntryNotReady(f"Failed to connect: {err}") from err
+    # Build coordinator and do the first data fetch
+    update_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    coordinator = CrowShepherdCoordinator(hass, hub, update_interval)
+    await coordinator.async_config_entry_first_refresh()
 
-    if hub.panel is None:
-        raise ConfigEntryNotReady("Could not find panel with specified MAC address")
+    hass.data[DOMAIN][entry.entry_id] = {
+        DATA_HUB: hub,
+        DATA_COORDINATOR: coordinator,
+    }
 
-    # Store the hub
-    hass.data[DOMAIN][entry.entry_id] = {DATA_HUB: hub}
-
-    # Set up platforms
+    # Forward setup to all platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Start WebSocket connection for real-time updates
-    hass.loop.create_task(hub.ws_connect())
+    # Reload on options change
+    entry.async_on_unload(entry.add_update_listener(_async_update_options))
 
-    # Register update listener for options
-    entry.async_on_unload(entry.add_update_listener(async_update_options))
+    # Start WebSocket reconnect loop in the background
+    ws_task = hass.async_create_background_task(
+        _ws_loop(hass, entry.entry_id),
+        name=f"crow_shepherd_ws_{entry.entry_id}",
+    )
+    hass.data[DOMAIN][entry.entry_id]["ws_task"] = ws_task
+
+    # Register bypass_zone service (idempotent — only registers once)
+    if not hass.services.has_service(DOMAIN, "bypass_zone"):
+        hass.services.async_register(
+            DOMAIN,
+            "bypass_zone",
+            _handle_bypass_zone,
+            schema=BYPASS_ZONE_SCHEMA,
+        )
 
     return True
 
 
-async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Handle options update."""
-    await hass.config_entries.async_reload(entry.entry_id)
-
-
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    # Cancel the WebSocket loop
+    entry_data = hass.data[DOMAIN].get(entry.entry_id, {})
+    ws_task: asyncio.Task | None = entry_data.get("ws_task")
+    if ws_task and not ws_task.done():
+        ws_task.cancel()
+        try:
+            await ws_task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+
+    # Close the session
+    hub: CrowHub | None = entry_data.get(DATA_HUB)
+    if hub:
+        await hub.async_close()
+
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.entry_id, None)
 
     return unload_ok
 
 
+async def _async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the entry when options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket reconnect loop
+# ---------------------------------------------------------------------------
+
+async def _ws_loop(hass: HomeAssistant, entry_id: str) -> None:
+    """Keep the WebSocket connected, reconnecting after any failure."""
+    while True:
+        entry_data = hass.data.get(DOMAIN, {}).get(entry_id)
+        if entry_data is None:
+            return  # Entry was unloaded
+
+        hub: CrowHub = entry_data[DATA_HUB]
+        coordinator: CrowShepherdCoordinator = entry_data[DATA_COORDINATOR]
+
+        async def _on_ws_message(msg: dict) -> None:
+            _LOGGER.debug("WebSocket message received: %s", msg)
+            coordinator.async_request_refresh()
+
+        try:
+            _LOGGER.debug("Starting WebSocket connection for panel %s", hub.mac)
+            await hub.session.ws_connect(hub.mac, _on_ws_message)
+            _LOGGER.debug("WebSocket connection closed for panel %s", hub.mac)
+        except asyncio.CancelledError:
+            return  # Clean shutdown
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning(
+                "WebSocket error for panel %s: %s — reconnecting in %ss",
+                hub.mac,
+                err,
+                _WS_RECONNECT_DELAY,
+            )
+
+        try:
+            await asyncio.sleep(_WS_RECONNECT_DELAY)
+        except asyncio.CancelledError:
+            return
+
+
+# ---------------------------------------------------------------------------
+# bypass_zone service
+# ---------------------------------------------------------------------------
+
+async def _handle_bypass_zone(call: ServiceCall) -> None:
+    """Handle the crow_shepherd.bypass_zone service call."""
+    zone_id: int = call.data["zone_id"]
+    bypass: bool = call.data["bypass"]
+    hass: HomeAssistant = call.hass
+
+    entry_data_list = hass.data.get(DOMAIN, {})
+    if not entry_data_list:
+        _LOGGER.error("bypass_zone: no Crow Shepherd entries found")
+        return
+
+    for entry_id, entry_data in entry_data_list.items():
+        coordinator: CrowShepherdCoordinator | None = entry_data.get(DATA_COORDINATOR)
+        if coordinator is None:
+            continue
+        try:
+            await coordinator.hub.panel.set_zone_bypass(zone_id, bypass)
+            await coordinator.async_request_refresh()
+            _LOGGER.debug(
+                "Zone %s bypass set to %s on panel %s",
+                zone_id,
+                bypass,
+                coordinator.hub.mac,
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error(
+                "Failed to set zone %s bypass on panel %s: %s",
+                zone_id,
+                coordinator.hub.mac,
+                err,
+            )
+
+
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
+    from homeassistant.const import CONF_EMAIL
+
     _LOGGER.debug(
         "Migrating configuration from version %s.%s",
         config_entry.version,
@@ -87,29 +194,17 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     )
 
     if config_entry.version > 2:
-        # This means the user has downgraded from a future version
         return False
 
     if config_entry.version == 1:
         new_data = {**config_entry.data}
-        
-        # Migrate panel_id to panel_mac if necessary
-        if "panel_id" in new_data and CONF_PANEL_MAC not in new_data:
-            new_data[CONF_PANEL_MAC] = new_data.pop("panel_id")
-        
-        # Migrate username to email if necessary
+        if "panel_id" in new_data and "panel_mac" not in new_data:
+            new_data["panel_mac"] = new_data.pop("panel_id")
         if "username" in new_data and CONF_EMAIL not in new_data:
             new_data[CONF_EMAIL] = new_data.pop("username")
-
         hass.config_entries.async_update_entry(
-            config_entry,
-            data=new_data,
-            version=2,
+            config_entry, data=new_data, version=2
         )
 
-    _LOGGER.debug(
-        "Migration to configuration version %s successful",
-        config_entry.version,
-    )
-
+    _LOGGER.debug("Migration to version %s successful", config_entry.version)
     return True

--- a/custom_components/crow_shepherd/alarm_control_panel.py
+++ b/custom_components/crow_shepherd/alarm_control_panel.py
@@ -4,38 +4,34 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from crow_security_ng import ResponseError
+from crow_security_ng.exceptions import ResponseError
+from crow_security_ng.models import Area, AreaCommand, AreaState
 
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityFeature,
     AlarmControlPanelState,
-    CodeFormat,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    ATTR_PANEL_MAC,
-    ATTR_PANEL_NAME,
-    DATA_HUB,
-    DOMAIN,
-    SET_STATE_MAP,
-    STATE_MAP,
-)
-from .hub import CrowHub
+from .const import DATA_COORDINATOR, DOMAIN
+from .coordinator import CrowShepherdCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-# State mappings from API to Home Assistant
-HA_STATE_MAP = {
-    "armed": AlarmControlPanelState.ARMED_AWAY,
-    "arm in progress": AlarmControlPanelState.ARMING,
-    "stay arm in progress": AlarmControlPanelState.ARMING,
-    "stay_armed": AlarmControlPanelState.ARMED_HOME,
-    "disarmed": AlarmControlPanelState.DISARMED,
+# Authoritative AreaState → AlarmControlPanelState mapping
+_AREA_STATE_MAP: dict[AreaState, AlarmControlPanelState] = {
+    AreaState.DISARMED: AlarmControlPanelState.DISARMED,
+    AreaState.ARMED: AlarmControlPanelState.ARMED_AWAY,
+    AreaState.STAY_ARMED: AlarmControlPanelState.ARMED_HOME,
+    AreaState.ARM_IN_PROGRESS: AlarmControlPanelState.ARMING,
+    AreaState.STAY_ARM_IN_PROGRESS: AlarmControlPanelState.ARMING,
+    AreaState.TRIGGERED: AlarmControlPanelState.TRIGGERED,
+    AreaState.PENDING: AlarmControlPanelState.PENDING,
 }
 
 
@@ -44,152 +40,138 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Crow Shepherd alarm control panel from config entry."""
-    hub: CrowHub = hass.data[DOMAIN][entry.entry_id][DATA_HUB]
-    
-    alarms = []
-    areas = await hub.get_areas()
-    
-    for area in areas:
-        alarms.append(CrowShepherdAlarmControlPanel(hub, area))
-    
-    async_add_entities(alarms)
+    """Set up alarm control panel entities from a config entry."""
+    coordinator: CrowShepherdCoordinator = hass.data[DOMAIN][entry.entry_id][
+        DATA_COORDINATOR
+    ]
+    async_add_entities(
+        CrowShepherdAlarmControlPanel(coordinator, area)
+        for area in coordinator.data.areas
+    )
 
 
-class CrowShepherdAlarmControlPanel(AlarmControlPanelEntity):
-    """Representation of a Crow Shepherd alarm control panel."""
+class CrowShepherdAlarmControlPanel(
+    CoordinatorEntity[CrowShepherdCoordinator],
+    AlarmControlPanelEntity,
+):
+    """One alarm control panel entity per Crow area/partition."""
 
     _attr_has_entity_name = True
     _attr_supported_features = (
         AlarmControlPanelEntityFeature.ARM_HOME
         | AlarmControlPanelEntityFeature.ARM_AWAY
     )
+    # The panel user_code is wired server-side via hub.py — no UI code entry needed.
+    _attr_code_arm_required = False
 
-    def __init__(self, hub: CrowHub, area: dict[str, Any]) -> None:
-        """Initialize the alarm control panel."""
-        self._hub = hub
-        self._panel = hub.panel
-        self._area = area
-        
-        # Use DISARMED as fallback state
-        self._state = HA_STATE_MAP.get(
-            self._area.get("state"), AlarmControlPanelState.DISARMED
-        )
-        _LOGGER.debug("Initialized alarm state for %s: %s", self.name, self._state)
+    def __init__(
+        self,
+        coordinator: CrowShepherdCoordinator,
+        area: Area,
+    ) -> None:
+        """Initialise entity."""
+        super().__init__(coordinator)
+        self._area_id = area.id
+        self._attr_unique_id = f"{coordinator.hub.mac}_{area.id}"
+        self._attr_name = area.name
 
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        return f"{self._hub.mac}_{self._area.get('id', 'area')}"
-
-    @property
-    def name(self) -> str:
-        """Return the name of the device."""
-        panel_name = self._panel.name if self._panel else "Crow"
-        area_name = self._area.get("name", "Alarm")
-        return f"{panel_name} {area_name}"
+    # ------------------------------------------------------------------
+    # Device info (all entities share one device per panel)
+    # ------------------------------------------------------------------
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info."""
+        panel = self.coordinator.hub.panel
         return DeviceInfo(
-            identifiers={(DOMAIN, self._hub.mac)},
-            name=self._panel.name if self._panel else "Crow Shepherd",
+            identifiers={(DOMAIN, self.coordinator.hub.mac)},
+            name=panel.name,
             manufacturer="Crow",
-            model="Shepherd",
+            model=panel.firmware_version or "Alarm Panel",
+        )
+
+    # ------------------------------------------------------------------
+    # State
+    # ------------------------------------------------------------------
+
+    def _get_area(self) -> Area | None:
+        """Return the current Area object from coordinator data."""
+        return next(
+            (a for a in self.coordinator.data.areas if a.id == self._area_id),
+            None,
         )
 
     @property
     def alarm_state(self) -> AlarmControlPanelState | None:
-        """Return the state of the alarm."""
-        return self._state
-
-    @property
-    def code_format(self) -> CodeFormat | None:
-        """Return the format of the code."""
-        return CodeFormat.NUMBER
+        """Return the current alarm state."""
+        area = self._get_area()
+        if area is None:
+            return None
+        state = _AREA_STATE_MAP.get(area.state)
+        if state is None:
+            _LOGGER.warning(
+                "Unknown AreaState %r for area %s — reporting DISARMED",
+                area.state,
+                self._area_id,
+            )
+            return AlarmControlPanelState.DISARMED
+        return state
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
+        area = self._get_area()
+        if area is None:
+            return {}
         return {
-            ATTR_PANEL_MAC: self._hub.mac,
-            ATTR_PANEL_NAME: self._panel.name if self._panel else None,
-            "area_id": self._area.get("id"),
-            "area_name": self._area.get("name"),
-            "raw_state": self._area.get("state"),
+            "area_id": area.id,
+            "area_name": area.name,
+            "raw_state": area.state.value if area.state else None,
+            "ready_to_arm": area.ready_to_arm,
+            "ready_to_stay": area.ready_to_stay,
+            "zone_alarm": area.zone_alarm,
         }
 
-    async def async_update(self) -> None:
-        """Update alarm status."""
-        area = await self._hub.get_area(self._area.get("id"))
-        
-        _LOGGER.debug("Area type is %s", type(area))
-        
-        if area is not None and isinstance(area, dict):
-            self._area = area
-        
-        _LOGGER.debug("Updating Crow area %s", self._area.get("name"))
-
-        # Log the current state before updating
-        received_state = self._area.get("state")
-        _LOGGER.debug("Current state before update: %s", received_state)
-
-        # Log unknown state for debugging
-        if received_state not in HA_STATE_MAP:
-            _LOGGER.warning(
-                "Unknown alarm state received: %s. Mapping to DISARMED.",
-                received_state
-            )
-
-        # Use DISARMED as fallback state if the state is unknown
-        self._state = HA_STATE_MAP.get(received_state, AlarmControlPanelState.DISARMED)
-        _LOGGER.debug("State successfully updated: %s", self._state)
+    # ------------------------------------------------------------------
+    # Commands
+    # ------------------------------------------------------------------
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
-        await self._async_set_arm_state(AlarmControlPanelState.DISARMED, code)
+        await self._send_command(AreaCommand.DISARM)
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
-        """Send arm home command."""
-        await self._async_set_arm_state(AlarmControlPanelState.ARMED_HOME, code)
+        """Send arm-home (stay) command."""
+        await self._send_command(AreaCommand.STAY)
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
-        """Send arm away command."""
-        await self._async_set_arm_state(AlarmControlPanelState.ARMED_AWAY, code)
+        """Send arm-away command."""
+        await self._send_command(AreaCommand.ARM)
 
-    async def async_alarm_trigger(self, code: str | None = None) -> None:
-        """Trigger alarm - not supported."""
-        pass
-
-    async def async_alarm_arm_custom_bypass(self, code: str | None = None) -> None:
-        """Custom bypass command - not supported."""
-        pass
-
-    async def _async_set_arm_state(
-        self, state: AlarmControlPanelState, code: str | None = None
-    ) -> None:
-        """Send set arm state command."""
-        # Map HA state to API command
-        api_command_map = {
-            AlarmControlPanelState.ARMED_HOME: "stay",
-            AlarmControlPanelState.ARMED_AWAY: "arm",
-            AlarmControlPanelState.DISARMED: "disarm",
-        }
-        
-        api_command = api_command_map.get(state, "disarm")
-        _LOGGER.info("Crow set arm state %s (API: %s)", state, api_command)
-        
+    async def _send_command(self, command: AreaCommand) -> None:
+        """Send an arm/disarm command and request a coordinator refresh."""
+        _LOGGER.debug("Area %s: sending command %s", self._area_id, command)
         try:
-            area = await self._panel.set_area_state(
-                self._area.get("id"), api_command
-            )
-            if area:
-                self._area = area
+            await self.coordinator.hub.panel.set_area_state(self._area_id, command)
         except ResponseError as err:
             if err.status_code == 408:
-                _LOGGER.debug("Received expected 408 error when setting arm state.")
+                # 408 is expected on successful arm — the panel takes time to confirm.
+                _LOGGER.debug(
+                    "Area %s: received expected 408 after %s", self._area_id, command
+                )
             else:
-                _LOGGER.error("Error setting arm state: %s", err)
-        except Exception as err:
-            _LOGGER.error("Unexpected error setting arm state: %s", err)
+                _LOGGER.error(
+                    "Area %s: API error %s during %s: %s",
+                    self._area_id,
+                    err.status_code,
+                    command,
+                    err,
+                )
+                return
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error(
+                "Area %s: unexpected error during %s: %s", self._area_id, command, err
+            )
+            return
+
+        await self.coordinator.async_request_refresh()

--- a/custom_components/crow_shepherd/binary_sensor.py
+++ b/custom_components/crow_shepherd/binary_sensor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from crow_security_ng.models import Zone
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -12,47 +14,17 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    ATTR_BATTERY_LEVEL,
-    ATTR_SIGNAL_STRENGTH,
-    ATTR_ZONE_ID,
-    ATTR_ZONE_NAME,
-    ATTR_ZONE_TYPE,
-    DATA_HUB,
-    DOMAIN,
-    ZONE_STATE_ALARM,
-    ZONE_STATE_OK,
-    ZONE_STATE_OPEN,
-    ZONE_STATE_TAMPER,
-    ZONE_STATE_TROUBLE,
-    ZONE_TYPE_DOOR,
-    ZONE_TYPE_GAS,
-    ZONE_TYPE_GLASS,
-    ZONE_TYPE_MEDICAL,
-    ZONE_TYPE_MOTION,
-    ZONE_TYPE_PANIC,
-    ZONE_TYPE_SMOKE,
-    ZONE_TYPE_TEMPERATURE,
-    ZONE_TYPE_WATER,
-    ZONE_TYPE_WINDOW,
-)
-from .hub import CrowHub
+from .const import DATA_COORDINATOR, DOMAIN
+from .coordinator import CrowShepherdCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-# Map zone types to device classes
-ZONE_TYPE_TO_DEVICE_CLASS = {
-    ZONE_TYPE_DOOR: BinarySensorDeviceClass.DOOR,
-    ZONE_TYPE_WINDOW: BinarySensorDeviceClass.WINDOW,
-    ZONE_TYPE_MOTION: BinarySensorDeviceClass.MOTION,
-    ZONE_TYPE_SMOKE: BinarySensorDeviceClass.SMOKE,
-    ZONE_TYPE_WATER: BinarySensorDeviceClass.MOISTURE,
-    ZONE_TYPE_GLASS: BinarySensorDeviceClass.VIBRATION,
-    ZONE_TYPE_PANIC: BinarySensorDeviceClass.SAFETY,
-    ZONE_TYPE_MEDICAL: BinarySensorDeviceClass.SAFETY,
-    ZONE_TYPE_GAS: BinarySensorDeviceClass.GAS,
-    ZONE_TYPE_TEMPERATURE: BinarySensorDeviceClass.HEAT,
+# Mapping of Crow zone_type integers to HA BinarySensorDeviceClass.
+# Add entries as additional types are confirmed from Crow documentation.
+_ZONE_TYPE_TO_DEVICE_CLASS: dict[int, BinarySensorDeviceClass] = {
+    55: BinarySensorDeviceClass.MOTION,  # Smart cam / PIR camera
 }
 
 
@@ -61,153 +33,77 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Crow Shepherd binary sensors from config entry."""
-    hub: CrowHub = hass.data[DOMAIN][entry.entry_id][DATA_HUB]
-
-    entities: list[CrowShepherdZoneSensor] = []
-
-    # Get zones from the hub
-    zones = await hub.get_devices()
-
-    for zone in zones:
-        zone_id = zone.get("id") or zone.get("zoneId") or zone.get("zone_id")
-        if zone_id:
-            entities.append(CrowShepherdZoneSensor(hub, zone))
-
-    async_add_entities(entities)
+    """Set up binary sensor entities from a config entry."""
+    coordinator: CrowShepherdCoordinator = hass.data[DOMAIN][entry.entry_id][
+        DATA_COORDINATOR
+    ]
+    async_add_entities(
+        CrowShepherdZoneSensor(coordinator, zone)
+        for zone in coordinator.data.zones
+    )
 
 
-class CrowShepherdZoneSensor(BinarySensorEntity):
-    """Representation of a Crow Shepherd zone sensor."""
+class CrowShepherdZoneSensor(
+    CoordinatorEntity[CrowShepherdCoordinator],
+    BinarySensorEntity,
+):
+    """Binary sensor representing a Crow zone."""
 
     _attr_has_entity_name = True
 
-    def __init__(self, hub: CrowHub, zone_data: dict[str, Any]) -> None:
-        """Initialize the zone sensor."""
-        self._hub = hub
-        self._zone_data = zone_data
-        self._zone_id = (
-            zone_data.get("id") or 
-            zone_data.get("zoneId") or 
-            zone_data.get("zone_id")
-        )
-        self._attr_unique_id = f"{hub.mac}_zone_{self._zone_id}"
-        
-        # Set device class based on zone type
-        zone_type = self._get_zone_type()
-        self._attr_device_class = ZONE_TYPE_TO_DEVICE_CLASS.get(
-            zone_type, BinarySensorDeviceClass.OPENING
-        )
-
-    @property
-    def zone_id(self) -> str:
-        """Return the zone ID."""
-        return self._zone_id
-
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return (
-            self._zone_data.get("name") or 
-            self._zone_data.get("zoneName") or 
-            f"Zone {self._zone_id}"
-        )
-
-    def _get_zone_type(self) -> str:
-        """Get the zone type."""
-        zone_type = (
-            self._zone_data.get("type") or 
-            self._zone_data.get("zoneType") or 
-            self._zone_data.get("zone_type", "generic")
-        )
-        return zone_type.lower() if isinstance(zone_type, str) else "generic"
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if the zone is triggered/open."""
-        state = self._zone_data.get("state") or self._zone_data.get("status", ZONE_STATE_OK)
-        
-        if isinstance(state, str):
-            state = state.lower()
-        
-        # Zone is "on" (triggered) if it's open, in alarm, tampered, or has trouble
-        return state in (
-            ZONE_STATE_OPEN,
-            ZONE_STATE_ALARM,
-            ZONE_STATE_TAMPER,
-            ZONE_STATE_TROUBLE,
-            "1",
-            "active",
-            "triggered",
-            "violated",
+    def __init__(
+        self,
+        coordinator: CrowShepherdCoordinator,
+        zone: Zone,
+    ) -> None:
+        """Initialise entity."""
+        super().__init__(coordinator)
+        self._zone_id = zone.id
+        self._attr_unique_id = f"{coordinator.hub.mac}_zone_{zone.id}"
+        self._attr_name = zone.name
+        self._attr_device_class = _ZONE_TYPE_TO_DEVICE_CLASS.get(
+            zone.zone_type, BinarySensorDeviceClass.OPENING
         )
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info."""
+        panel = self.coordinator.hub.panel
         return DeviceInfo(
-            identifiers={(DOMAIN, self._hub.mac)},
-            name=self._hub.panel.name if self._hub.panel else "Crow Shepherd",
+            identifiers={(DOMAIN, self.coordinator.hub.mac)},
+            name=panel.name,
             manufacturer="Crow",
-            model="Shepherd",
+            model=panel.firmware_version or "Alarm Panel",
         )
+
+    def _get_zone(self) -> Zone | None:
+        """Return the current Zone object from coordinator data."""
+        return next(
+            (z for z in self.coordinator.data.zones if z.id == self._zone_id),
+            None,
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the zone is open/triggered.
+
+        Zone.state is a bool in crow_security_ng: True = open/triggered.
+        """
+        zone = self._get_zone()
+        return zone.state if zone is not None else False
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
-        attrs = {
-            ATTR_ZONE_ID: self._zone_id,
-            ATTR_ZONE_NAME: self._zone_data.get("name") or self._zone_data.get("zoneName"),
-            ATTR_ZONE_TYPE: self._get_zone_type(),
+        zone = self._get_zone()
+        if zone is None:
+            return {}
+        return {
+            "zone_id": zone.id,
+            "zone_type": zone.zone_type,
+            "bypassed": zone.bypass,
+            "tamper": zone.tamper_alarm,
+            "battery_low": zone.battery_low,
+            "active": zone.active,
+            "rssi": zone.rssi,
         }
-        
-        # Add battery level if available
-        battery = (
-            self._zone_data.get("battery") or 
-            self._zone_data.get("batteryLevel") or 
-            self._zone_data.get("battery_level")
-        )
-        if battery is not None:
-            attrs[ATTR_BATTERY_LEVEL] = battery
-        
-        # Add signal strength if available
-        signal = (
-            self._zone_data.get("signal") or 
-            self._zone_data.get("signalStrength") or 
-            self._zone_data.get("signal_strength") or 
-            self._zone_data.get("rssi")
-        )
-        if signal is not None:
-            attrs[ATTR_SIGNAL_STRENGTH] = signal
-        
-        # Add bypass status
-        bypassed = self._zone_data.get("bypassed") or self._zone_data.get("bypass", False)
-        attrs["bypassed"] = bypassed
-        
-        # Add tamper status
-        state = self._zone_data.get("state") or self._zone_data.get("status", "")
-        if isinstance(state, str):
-            attrs["tamper"] = state.lower() == ZONE_STATE_TAMPER
-        
-        # Add low battery status
-        if battery is not None:
-            try:
-                attrs["low_battery"] = float(battery) < 20
-            except (ValueError, TypeError):
-                attrs["low_battery"] = str(battery).lower() in ("low", "critical", "1")
-        
-        return attrs
-
-    async def async_update(self) -> None:
-        """Update zone state."""
-        zones = await self._hub.get_devices()
-        
-        for zone in zones:
-            zone_id = (
-                zone.get("id") or 
-                zone.get("zoneId") or 
-                zone.get("zone_id")
-            )
-            if zone_id == self._zone_id:
-                self._zone_data = zone
-                break

--- a/custom_components/crow_shepherd/config_flow.py
+++ b/custom_components/crow_shepherd/config_flow.py
@@ -2,12 +2,18 @@
 from __future__ import annotations
 
 import logging
-import re
 from typing import Any
 
-import crow_security_ng as crow
-from crow_security_ng import ResponseError
 import voluptuous as vol
+
+from crow_security_ng import Session
+from crow_security_ng.exceptions import (
+    AuthenticationError,
+    ConnectionError,
+    InvalidMacError,
+    PanelNotFoundError,
+)
+from crow_security_ng.utils import normalize_mac
 
 from homeassistant.config_entries import (
     ConfigEntry,
@@ -22,179 +28,138 @@ from .const import (
     CONF_PANEL_CODE,
     CONF_PANEL_MAC,
     CONF_SCAN_INTERVAL,
-    DEFAULT_NAME,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
+
+def _try_normalize_mac(raw: str) -> str | None:
+    """Return 12-char lowercase hex MAC, or None if the input is invalid.
+
+    Accepts both:
+      - compact form:   0013A1250A45
+      - colon-separated: 00:13:A1:25:0A:45
+    (and also dash-separated or space-separated variants)
+    """
+    try:
+        return normalize_mac(raw)
+    except InvalidMacError:
+        return None
+
+
+_STEP_USER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_EMAIL): str,
         vol.Required(CONF_PASSWORD): str,
         vol.Required(CONF_PANEL_MAC): str,
+        vol.Optional(CONF_PANEL_CODE, default=""): str,
     }
 )
 
 
-def normalize_mac_address(mac: str) -> str:
-    """Normalize MAC address by removing separators and converting to lowercase.
-    
-    Accepts formats like:
-    - AA:BB:CC:DD:EE:FF
-    - AA-BB-CC-DD-EE-FF
-    - AABBCCDDEEFF
-    - aa:bb:cc:dd:ee:ff
-    - AA BB CC DD EE FF
-    
-    Returns: aabbccddeeff (lowercase, no separators)
-    """
-    # Remove all common separators and whitespace
-    normalized = re.sub(r'[:\-\s.]', '', mac)
-    # Convert to lowercase
-    normalized = normalized.lower()
-    return normalized
-
-
-def format_mac_for_display(mac: str) -> str:
-    """Format MAC address for display (XX:XX:XX:XX:XX:XX)."""
-    normalized = normalize_mac_address(mac)
-    if len(normalized) == 12:
-        return ':'.join(normalized[i:i+2] for i in range(0, 12, 2)).upper()
-    return mac
-
-
-def is_valid_mac(mac: str) -> bool:
-    """Check if the MAC address is valid (12 hex characters after normalization)."""
-    normalized = normalize_mac_address(mac)
-    return bool(re.match(r'^[0-9a-f]{12}$', normalized))
-
-
 class CrowShepherdConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Crow Shepherd."""
+    """Handle the onboarding wizard for Crow Shepherd."""
 
     VERSION = 2
-
-    def __init__(self) -> None:
-        """Initialize the config flow."""
-        self._email: str | None = None
-        self._password: str | None = None
-        self._panel_mac: str | None = None
-        self._session: crow.Session | None = None
 
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
-        """Handle the initial step - user credentials and panel MAC."""
+        """First (and only) setup step — credentials + panel MAC."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            self._email = user_input[CONF_EMAIL]
-            self._password = user_input[CONF_PASSWORD]
-            raw_mac = user_input[CONF_PANEL_MAC]
-            
-            # Normalize the MAC address
-            self._panel_mac = normalize_mac_address(raw_mac)
-            
-            # Validate MAC format
-            if not is_valid_mac(raw_mac):
-                errors["base"] = "invalid_mac"
+            raw_mac = user_input[CONF_PANEL_MAC].strip()
+            normalized_mac = _try_normalize_mac(raw_mac)
+
+            if normalized_mac is None:
+                errors[CONF_PANEL_MAC] = "invalid_mac"
             else:
                 try:
-                    # Create session and try to get the panel
-                    session = crow.Session(self._email, self._password)
-                    panel = await session.get_panel(self._panel_mac)
-                    
-                    if panel is None:
-                        errors["base"] = "no_panel"
-                    else:
-                        # Set unique ID based on email and panel MAC
-                        await self.async_set_unique_id(f"{self._email}_{self._panel_mac}")
-                        self._abort_if_unique_id_configured()
+                    session = Session(
+                        user_input[CONF_EMAIL],
+                        user_input[CONF_PASSWORD],
+                    )
+                    panel = await session.get_panel(normalized_mac)
+                    await session.close()
 
-                        # Get panel name for entry title
-                        panel_name = panel.name if panel.name else DEFAULT_NAME
+                    # Use only the MAC as unique ID (not email+mac)
+                    await self.async_set_unique_id(normalized_mac)
+                    self._abort_if_unique_id_configured()
 
-                        return self.async_create_entry(
-                            title=panel_name,
-                            data={
-                                CONF_EMAIL: self._email,
-                                CONF_PASSWORD: self._password,
-                                CONF_PANEL_MAC: self._panel_mac,
-                            },
-                        )
-                        
-                except ResponseError as err:
-                    _LOGGER.error("Crow API error: %s - %s", err.status_code, err)
-                    if err.status_code == 401 or err.status_code == 403:
-                        errors["base"] = "invalid_auth"
-                    elif err.status_code == 404:
-                        errors["base"] = "no_panel"
-                    else:
-                        errors["base"] = "cannot_connect"
-                except Exception as err:  # pylint: disable=broad-except
-                    _LOGGER.exception("Unexpected exception: %s", err)
+                    panel_name = panel.name or "Crow Shepherd"
+                    panel_code = user_input.get(CONF_PANEL_CODE, "").strip() or None
+
+                    entry_data: dict[str, Any] = {
+                        CONF_EMAIL: user_input[CONF_EMAIL],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                        CONF_PANEL_MAC: normalized_mac,
+                    }
+                    if panel_code:
+                        entry_data[CONF_PANEL_CODE] = panel_code
+
+                    return self.async_create_entry(title=panel_name, data=entry_data)
+
+                except AuthenticationError:
+                    errors["base"] = "invalid_auth"
+                except PanelNotFoundError:
+                    errors["base"] = "no_panel"
+                except ConnectionError:
+                    errors["base"] = "cannot_connect"
+                except Exception:  # noqa: BLE001
+                    _LOGGER.exception("Unexpected error during config flow")
                     errors["base"] = "unknown"
 
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=_STEP_USER_SCHEMA,
             errors=errors,
-            description_placeholders={
-                "mac_format": "AABBCCDDEEFF or AA:BB:CC:DD:EE:FF",
-            },
         )
 
     async def async_step_reauth(
         self,
         entry_data: dict[str, Any],
     ) -> ConfigFlowResult:
-        """Handle reauthorization."""
+        """Start reauthentication."""
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self,
         user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
-        """Handle reauthorization confirmation."""
+        """Handle reauthentication with new credentials."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            entry = self._get_reauth_entry()
+            stored_mac = entry.data[CONF_PANEL_MAC]
             try:
-                # Test credentials
-                session = crow.Session(
+                session = Session(
                     user_input[CONF_EMAIL],
-                    user_input[CONF_PASSWORD]
+                    user_input[CONF_PASSWORD],
                 )
-                
-                entry = self._get_reauth_entry()
-                panel = await session.get_panel(entry.data[CONF_PANEL_MAC])
-                
-                if panel is None:
-                    errors["base"] = "no_panel"
-                else:
-                    # Update the config entry
-                    return self.async_update_reload_and_abort(
-                        entry,
-                        data={
-                            **entry.data,
-                            CONF_EMAIL: user_input[CONF_EMAIL],
-                            CONF_PASSWORD: user_input[CONF_PASSWORD],
-                        },
-                    )
-                
-            except ResponseError as err:
-                _LOGGER.error("Crow API error: %s", err)
-                if err.status_code == 401 or err.status_code == 403:
-                    errors["base"] = "invalid_auth"
-                elif err.status_code == 404:
-                    errors["base"] = "no_panel"
-                else:
-                    errors["base"] = "cannot_connect"
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
+                await session.get_panel(stored_mac)
+                await session.close()
+
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data={
+                        **entry.data,
+                        CONF_EMAIL: user_input[CONF_EMAIL],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+            except AuthenticationError:
+                errors["base"] = "invalid_auth"
+            except PanelNotFoundError:
+                errors["base"] = "no_panel"
+            except ConnectionError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Unexpected error during reauth")
                 errors["base"] = "unknown"
 
         return self.async_show_form(
@@ -210,27 +175,34 @@ class CrowShepherdConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(
-        config_entry: ConfigEntry,
-    ) -> OptionsFlow:
-        """Get the options flow for this handler."""
-        return CrowShepherdOptionsFlowHandler(config_entry)
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Return the options flow handler."""
+        return CrowShepherdOptionsFlow(config_entry)
 
 
-class CrowShepherdOptionsFlowHandler(OptionsFlow):
-    """Handle options flow for Crow Shepherd."""
+class CrowShepherdOptionsFlow(OptionsFlow):
+    """Options flow — update scan interval and panel code."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize options flow."""
+        """Initialise options flow."""
         self.config_entry = config_entry
 
     async def async_step_init(
         self,
         user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
-        """Manage the options."""
+        """Show and handle the options form."""
         if user_input is not None:
+            # Strip empty panel_code so we don't store an empty string
+            if not user_input.get(CONF_PANEL_CODE, "").strip():
+                user_input.pop(CONF_PANEL_CODE, None)
             return self.async_create_entry(title="", data=user_input)
+
+        current_code = (
+            self.config_entry.options.get(CONF_PANEL_CODE)
+            or self.config_entry.data.get(CONF_PANEL_CODE)
+            or ""
+        )
 
         return self.async_show_form(
             step_id="init",
@@ -244,7 +216,7 @@ class CrowShepherdOptionsFlowHandler(OptionsFlow):
                     ): vol.All(vol.Coerce(int), vol.Range(min=10, max=300)),
                     vol.Optional(
                         CONF_PANEL_CODE,
-                        default=self.config_entry.data.get(CONF_PANEL_CODE, ""),
+                        default=current_code,
                     ): str,
                 }
             ),

--- a/custom_components/crow_shepherd/const.py
+++ b/custom_components/crow_shepherd/const.py
@@ -5,56 +5,13 @@ from typing import Final
 
 DOMAIN: Final = "crow_shepherd"
 
-# Configuration
+# Configuration keys
 CONF_PANEL_MAC: Final = "panel_mac"
 CONF_PANEL_CODE: Final = "panel_code"
 CONF_SCAN_INTERVAL: Final = "scan_interval"
 
 # Default values
 DEFAULT_SCAN_INTERVAL: Final = 30
-DEFAULT_NAME: Final = "Crow Shepherd"
-
-# Alarm states mapping from API to Home Assistant
-STATE_MAP: Final = {
-    "armed": "armed_away",
-    "arm in progress": "arming",
-    "stay arm in progress": "arming",
-    "stay_armed": "armed_home",
-    "disarmed": "disarmed",
-}
-
-# Arm state commands to send to API
-SET_STATE_MAP: Final = {
-    "armed_home": "stay",
-    "armed_away": "arm",
-    "disarm": "disarm",
-}
-
-# Zone types
-ZONE_TYPE_DOOR: Final = "door"
-ZONE_TYPE_WINDOW: Final = "window"
-ZONE_TYPE_MOTION: Final = "motion"
-ZONE_TYPE_SMOKE: Final = "smoke"
-ZONE_TYPE_WATER: Final = "water"
-ZONE_TYPE_GLASS: Final = "glass"
-ZONE_TYPE_PANIC: Final = "panic"
-ZONE_TYPE_MEDICAL: Final = "medical"
-ZONE_TYPE_GAS: Final = "gas"
-ZONE_TYPE_TEMPERATURE: Final = "temperature"
-ZONE_TYPE_GENERIC: Final = "generic"
-
-# Zone states
-ZONE_STATE_OK: Final = "ok"
-ZONE_STATE_OPEN: Final = "open"
-ZONE_STATE_TAMPER: Final = "tamper"
-ZONE_STATE_ALARM: Final = "alarm"
-ZONE_STATE_TROUBLE: Final = "trouble"
-ZONE_STATE_BYPASSED: Final = "bypassed"
-ZONE_STATE_LOWBATT: Final = "low_battery"
-
-# Output states
-OUTPUT_STATE_ON: Final = "on"
-OUTPUT_STATE_OFF: Final = "off"
 
 # Platforms
 PLATFORMS: Final = [
@@ -64,22 +21,6 @@ PLATFORMS: Final = [
     "sensor",
 ]
 
-# Data keys
+# hass.data keys
 DATA_HUB: Final = "hub"
-
-# Events
-EVENT_ALARM_TRIGGERED: Final = f"{DOMAIN}_alarm_triggered"
-EVENT_ZONE_OPENED: Final = f"{DOMAIN}_zone_opened"
-EVENT_ZONE_TAMPER: Final = f"{DOMAIN}_zone_tamper"
-
-# Attributes
-ATTR_PANEL_MAC: Final = "panel_mac"
-ATTR_PANEL_NAME: Final = "panel_name"
-ATTR_ZONE_ID: Final = "zone_id"
-ATTR_ZONE_NAME: Final = "zone_name"
-ATTR_ZONE_TYPE: Final = "zone_type"
-ATTR_LAST_EVENT: Final = "last_event"
-ATTR_LAST_TRIGGERED: Final = "last_triggered"
-ATTR_BATTERY_LEVEL: Final = "battery_level"
-ATTR_SIGNAL_STRENGTH: Final = "signal_strength"
-ATTR_FIRMWARE_VERSION: Final = "firmware_version"
+DATA_COORDINATOR: Final = "coordinator"

--- a/custom_components/crow_shepherd/coordinator.py
+++ b/custom_components/crow_shepherd/coordinator.py
@@ -1,0 +1,75 @@
+"""DataUpdateCoordinator for the Crow Shepherd integration."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from crow_security_ng.exceptions import AuthenticationError, ConnectionError, ResponseError
+from crow_security_ng.models import Area, Measurement, Output, Zone
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+if TYPE_CHECKING:
+    from .hub import CrowHub
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class CrowData:
+    """All data fetched from the Crow panel in one coordinator refresh."""
+
+    areas: list[Area] = field(default_factory=list)
+    zones: list[Zone] = field(default_factory=list)
+    outputs: list[Output] = field(default_factory=list)
+    measurements: list[Measurement] = field(default_factory=list)
+
+
+class CrowShepherdCoordinator(DataUpdateCoordinator[CrowData]):
+    """Coordinator that polls the Crow panel for all entity data."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        hub: "CrowHub",
+        update_interval: int,
+    ) -> None:
+        """Initialise the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Crow Shepherd",
+            update_interval=timedelta(seconds=update_interval),
+        )
+        self.hub = hub
+
+    async def _async_update_data(self) -> CrowData:
+        """Fetch all data from the panel.  Raises UpdateFailed on transient errors."""
+        panel = self.hub.panel
+        try:
+            areas = await panel.get_areas()
+            zones = await panel.get_zones()
+            outputs = await panel.get_outputs()
+            try:
+                measurements = await panel.get_measurements()
+            except Exception:  # noqa: BLE001
+                # Measurements are optional — don't fail the whole refresh
+                measurements = []
+
+            return CrowData(
+                areas=areas,
+                zones=zones,
+                outputs=outputs,
+                measurements=measurements,
+            )
+
+        except AuthenticationError as err:
+            raise ConfigEntryAuthFailed(
+                "Crow Cloud rejected the credentials during refresh"
+            ) from err
+        except (ConnectionError, ResponseError) as err:
+            raise UpdateFailed(f"Error communicating with Crow Cloud: {err}") from err

--- a/custom_components/crow_shepherd/hub.py
+++ b/custom_components/crow_shepherd/hub.py
@@ -1,224 +1,102 @@
-"""Hub for Crow Shepherd integration using crow_security library."""
+"""Hub for Crow Shepherd — thin wrapper around crow_security_ng Session/Panel."""
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
-from typing import Any, Callable
 
-import crow_security_ng as crow
-from crow_security_ng import Panel
-from crow_security_ng import ResponseError
+from crow_security_ng import Session
+from crow_security_ng.exceptions import AuthenticationError, ConnectionError, PanelNotFoundError
+from crow_security_ng.models import Panel
 
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
-from homeassistant.core import HomeAssistant
-from homeassistant.util import Throttle
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
-from .const import CONF_PANEL_MAC, DOMAIN, SET_STATE_MAP, STATE_MAP
+from .const import CONF_PANEL_CODE, CONF_PANEL_MAC
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class CrowHub:
-    """Hub for managing connection to Crow Cloud."""
+    """Holds the authenticated Session and the resolved Panel object."""
 
-    def __init__(self, config: dict[str, Any], hass: HomeAssistant) -> None:
-        """Initialize the hub."""
-        self._hass = hass
-        self._mac = config[CONF_PANEL_MAC]
+    def __init__(
+        self,
+        email: str,
+        password: str,
+        mac: str,
+        panel_code: str | None = None,
+    ) -> None:
+        """Initialise hub; does NOT connect yet."""
+        self._mac = mac
+        self._panel_code = panel_code or None
+        self._session = Session(email, password)
         self._panel: Panel | None = None
-        self._devices: list[dict[str, Any]] | None = None
-        self._outputs: list[dict[str, Any]] | None = None
-        self._measurements: list[dict[str, Any]] | None = None
-        self._areas: list[dict[str, Any]] | None = None
-        self._subscriptions: dict[str, Callable] = {}
-        
-        _LOGGER.info("Initializing Crow Hub with MAC: %s", self._mac)
-        
-        self.session = crow.Session(
-            config[CONF_EMAIL],
-            config[CONF_PASSWORD]
-        )
+
+    # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
 
     @property
     def mac(self) -> str:
-        """Return the panel MAC address."""
+        """Return the normalised panel MAC address."""
         return self._mac
 
     @property
-    def panel(self) -> Panel | None:
-        """Return the panel object."""
+    def session(self) -> Session:
+        """Return the authenticated session."""
+        return self._session
+
+    @property
+    def panel(self) -> Panel:
+        """Return the resolved Panel.  Raises if async_connect not yet called."""
+        if self._panel is None:
+            raise RuntimeError("CrowHub.async_connect() has not been called yet")
         return self._panel
 
-    async def init_panel(self) -> None:
-        """Initialize the panel connection."""
-        self._panel = await self.session.get_panel(self._mac)
-        _LOGGER.info("Panel initialized: %s", self._panel.name if self._panel else "Unknown")
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
 
-    async def async_test_connection(self) -> bool:
-        """Test if we can connect to the Crow Cloud."""
+    async def async_connect(self) -> None:
+        """Login and resolve the panel.  Raises HA exceptions on failure."""
         try:
-            panel = await self.session.get_panel(self._mac)
-            return panel is not None
-        except Exception as err:
-            _LOGGER.error("Connection test failed: %s", err)
-            return False
+            self._panel = await self._session.get_panel(self._mac)
+        except AuthenticationError as err:
+            raise ConfigEntryAuthFailed(
+                "Crow Cloud authentication failed — check email/password"
+            ) from err
+        except PanelNotFoundError as err:
+            raise ConfigEntryNotReady(
+                f"Panel {self._mac!r} not found on Crow Cloud"
+            ) from err
+        except ConnectionError as err:
+            raise ConfigEntryNotReady(
+                f"Could not reach Crow Cloud: {err}"
+            ) from err
 
-    @Throttle(timedelta(seconds=60))
-    async def _get_devices(self) -> list[dict[str, Any]] | None:
-        """Get devices (zones) from the panel."""
+        # Wire the user code so arm/disarm headers are sent automatically.
+        if self._panel_code:
+            self._panel.user_code = self._panel_code
+
+        _LOGGER.debug("Panel connected: %s (id=%s)", self._panel.name, self._panel.id)
+
+    async def async_close(self) -> None:
+        """Close the underlying session."""
         try:
-            zones = await self.panel.get_zones()
-            return zones
-        except ResponseError as ex:
-            _LOGGER.error("Failed to get zones: %s", ex)
-            return None
-        except Exception as ex:
-            _LOGGER.error("Unexpected error getting zones: %s", ex)
-            return None
+            await self._session.close()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Session close returned: %s", err)
 
-    async def get_devices(self) -> list[dict[str, Any]]:
-        """Get devices with caching."""
-        devices = await self._get_devices()
-        if devices:
-            self._devices = devices
-        return self._devices or []
+    # ------------------------------------------------------------------
+    # Factory helper
+    # ------------------------------------------------------------------
 
-    @Throttle(timedelta(seconds=30))
-    async def _get_measurements(self) -> list[dict[str, Any]] | None:
-        """Get measurements from the panel."""
-        try:
-            return await self.panel.get_measurements()
-        except ResponseError as ex:
-            _LOGGER.error("Failed to get measurements: %s", ex)
-            return None
-        except Exception as ex:
-            _LOGGER.error("Unexpected error getting measurements: %s", ex)
-            return None
-
-    async def get_measurements(self) -> list[dict[str, Any]]:
-        """Get measurements with caching."""
-        measurements = await self._get_measurements()
-        if measurements:
-            self._measurements = measurements
-        return self._measurements or []
-
-    @Throttle(timedelta(seconds=30))
-    async def _get_outputs(self) -> list[dict[str, Any]] | None:
-        """Get outputs from the panel."""
-        try:
-            return await self.panel.get_outputs()
-        except ResponseError as ex:
-            _LOGGER.error("Failed to get outputs: %s", ex)
-            return None
-        except Exception as ex:
-            _LOGGER.error("Unexpected error getting outputs: %s", ex)
-            return None
-
-    async def get_outputs(self) -> list[dict[str, Any]]:
-        """Get outputs with caching."""
-        outputs = await self._get_outputs()
-        if outputs:
-            self._outputs = outputs
-        return self._outputs or []
-
-    async def get_areas(self) -> list[dict[str, Any]]:
-        """Get alarm areas/partitions."""
-        try:
-            areas = await self.panel.get_areas()
-            self._areas = areas
-            return areas
-        except ResponseError as ex:
-            _LOGGER.error("Failed to get areas: %s", ex)
-            return self._areas or []
-        except Exception as ex:
-            _LOGGER.error("Unexpected error getting areas: %s", ex)
-            return self._areas or []
-
-    async def get_area(self, area_id: str) -> dict[str, Any] | None:
-        """Get a specific area."""
-        try:
-            return await self.panel.get_area(area_id)
-        except ResponseError as ex:
-            _LOGGER.error("Failed to get area %s: %s", area_id, ex)
-            return None
-        except Exception as ex:
-            _LOGGER.error("Unexpected error getting area %s: %s", area_id, ex)
-            return None
-
-    async def set_area_state(self, area_id: str, state: str) -> dict[str, Any] | None:
-        """Set the state of an area (arm/disarm)."""
-        api_state = SET_STATE_MAP.get(state, "disarm")
-        _LOGGER.info("Setting area %s to state %s (API: %s)", area_id, state, api_state)
-        try:
-            return await self.panel.set_area_state(area_id, api_state)
-        except ResponseError as err:
-            if err.status_code == 408:
-                _LOGGER.debug("Received expected 408 response when setting arm state")
-                return None
-            _LOGGER.error("Failed to set area state: %s", err)
-            raise
-        except Exception as err:
-            _LOGGER.error("Unexpected error setting area state: %s", err)
-            raise
-
-    async def set_output_state(self, output_id: str, state: bool) -> bool:
-        """Set the state of an output."""
-        try:
-            await self.panel.set_output_state(output_id, state)
-            return True
-        except ResponseError as ex:
-            _LOGGER.error("Failed to set output state: %s", ex)
-            return False
-        except Exception as ex:
-            _LOGGER.error("Unexpected error setting output state: %s", ex)
-            return False
-
-    async def capture_cam_image(self, zone_id: str) -> bytes | None:
-        """Capture an image from a camera zone."""
-        try:
-            return await self.panel.capture_cam_image(zone_id)
-        except ResponseError as ex:
-            _LOGGER.error("Failed to capture camera image: %s", ex)
-            return None
-        except Exception as ex:
-            _LOGGER.error("Unexpected error capturing camera image: %s", ex)
-            return None
-
-    def subscribe(self, device_id: str, callback: Callable) -> None:
-        """Subscribe to updates for a device."""
-        self._subscriptions[device_id] = callback
-
-    def unsubscribe(self, device_id: str) -> None:
-        """Unsubscribe from updates for a device."""
-        self._subscriptions.pop(device_id, None)
-
-    async def ws_connect(self) -> None:
-        """Connect to WebSocket for real-time updates."""
-        async def ws_callback(msg: dict[str, Any]) -> None:
-            """Handle WebSocket messages."""
-            # Skip certain info messages
-            if (msg.get("type") == "info" and 
-                msg.get("data", {}).get("_id", {}).get("dect_interface") == 32768):
-                _LOGGER.debug("Skipping DECT info message")
-                return
-            
-            _LOGGER.debug("Received WebSocket message: %s", msg)
-            
-            # Find and call the appropriate callback
-            device_id = msg.get("data", {}).get("_id", {}).get("device_id")
-            if device_id and device_id in self._subscriptions:
-                callback = self._subscriptions[device_id]
-                try:
-                    callback(msg)
-                except Exception as err:
-                    _LOGGER.error("Error in subscription callback: %s", err)
-
-        try:
-            await self.session.ws_connect(self._mac, ws_callback)
-        except Exception as err:
-            _LOGGER.error("WebSocket connection failed: %s", err)
-
-    @staticmethod
-    def map_alarm_state(api_state: str) -> str:
-        """Map API alarm state to Home Assistant state."""
-        return STATE_MAP.get(api_state, "disarmed")
+    @classmethod
+    def from_config_entry(cls, data: dict, options: dict) -> "CrowHub":
+        """Build a CrowHub from config entry data + options dicts."""
+        panel_code = options.get(CONF_PANEL_CODE) or data.get(CONF_PANEL_CODE) or None
+        return cls(
+            email=data[CONF_EMAIL],
+            password=data[CONF_PASSWORD],
+            mac=data[CONF_PANEL_MAC],
+            panel_code=panel_code,
+        )

--- a/custom_components/crow_shepherd/manifest.json
+++ b/custom_components/crow_shepherd/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/tubalainen/crow_shepherd",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/tubalainen/crow_shepherd/issues",
-  "requirements": ["crow_security_ng>=0.1.6"],
-  "version": "0.0.5",
+  "requirements": ["crow_security_ng>=0.1.8"],
+  "version": "0.1.0",
   "integration_type": "hub"
 }

--- a/custom_components/crow_shepherd/sensor.py
+++ b/custom_components/crow_shepherd/sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platform for Crow Shepherd measurements and status."""
+"""Sensor platform for Crow Shepherd measurements."""
 from __future__ import annotations
 
 import logging
@@ -13,11 +13,22 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DATA_HUB, DOMAIN
-from .hub import CrowHub
+from .const import DATA_COORDINATOR, DOMAIN
+from .coordinator import CrowShepherdCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+# Map measurement type strings to HA SensorDeviceClass + unit
+_MEASUREMENT_TYPE_MAP: dict[str, tuple[SensorDeviceClass, str]] = {
+    "temperature": (SensorDeviceClass.TEMPERATURE, "°C"),
+    "temp": (SensorDeviceClass.TEMPERATURE, "°C"),
+    "humidity": (SensorDeviceClass.HUMIDITY, "%"),
+    "battery": (SensorDeviceClass.BATTERY, "%"),
+    "signal": (SensorDeviceClass.SIGNAL_STRENGTH, "dBm"),
+    "rssi": (SensorDeviceClass.SIGNAL_STRENGTH, "dBm"),
+}
 
 
 async def async_setup_entry(
@@ -25,102 +36,79 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Crow Shepherd sensors from config entry."""
-    hub: CrowHub = hass.data[DOMAIN][entry.entry_id][DATA_HUB]
-
-    entities: list[SensorEntity] = []
-
-    # Get measurements from the hub
-    measurements = await hub.get_measurements()
-    
-    for measurement in measurements:
-        measurement_id = (
-            measurement.get("id") or 
-            measurement.get("measurementId") or 
-            measurement.get("_id")
-        )
-        if measurement_id:
-            entities.append(CrowShepherdMeasurementSensor(hub, measurement))
-
-    # Add zone battery sensors
-    zones = await hub.get_devices()
-    for zone in zones:
-        zone_id = zone.get("id") or zone.get("zoneId") or zone.get("zone_id")
-        battery = (
-            zone.get("battery") or 
-            zone.get("batteryLevel") or 
-            zone.get("battery_level")
-        )
-        if zone_id and battery is not None:
-            entities.append(CrowShepherdZoneBatterySensor(hub, zone))
-
-    async_add_entities(entities)
+    """Set up sensor entities from a config entry."""
+    coordinator: CrowShepherdCoordinator = hass.data[DOMAIN][entry.entry_id][
+        DATA_COORDINATOR
+    ]
+    async_add_entities(
+        CrowShepherdMeasurementSensor(coordinator, idx)
+        for idx, _ in enumerate(coordinator.data.measurements)
+    )
 
 
-class CrowShepherdMeasurementSensor(SensorEntity):
-    """Sensor showing measurements from the alarm system."""
+class CrowShepherdMeasurementSensor(
+    CoordinatorEntity[CrowShepherdCoordinator],
+    SensorEntity,
+):
+    """Sensor showing a measurement value from the Crow panel."""
 
     _attr_has_entity_name = True
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, hub: CrowHub, measurement_data: dict[str, Any]) -> None:
-        """Initialize the sensor."""
-        self._hub = hub
-        self._measurement_data = measurement_data
-        self._measurement_id = (
-            measurement_data.get("id") or 
-            measurement_data.get("measurementId") or 
-            measurement_data.get("_id")
-        )
-        self._attr_unique_id = f"{hub.mac}_measurement_{self._measurement_id}"
-        
-        # Set device class based on measurement type
-        measurement_type = measurement_data.get("type", "").lower()
-        if "temperature" in measurement_type or "temp" in measurement_type:
-            self._attr_device_class = SensorDeviceClass.TEMPERATURE
-            self._attr_native_unit_of_measurement = "°C"
-            self._attr_state_class = SensorStateClass.MEASUREMENT
-        elif "humidity" in measurement_type:
-            self._attr_device_class = SensorDeviceClass.HUMIDITY
-            self._attr_native_unit_of_measurement = "%"
-            self._attr_state_class = SensorStateClass.MEASUREMENT
-        elif "battery" in measurement_type:
-            self._attr_device_class = SensorDeviceClass.BATTERY
-            self._attr_native_unit_of_measurement = "%"
-            self._attr_state_class = SensorStateClass.MEASUREMENT
-        elif "signal" in measurement_type or "rssi" in measurement_type:
-            self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
-            self._attr_native_unit_of_measurement = "dBm"
-            self._attr_state_class = SensorStateClass.MEASUREMENT
+    def __init__(
+        self,
+        coordinator: CrowShepherdCoordinator,
+        index: int,
+    ) -> None:
+        """Initialise entity using the list index to identify the measurement."""
+        super().__init__(coordinator)
+        # Use index + stable initial values to set the unique_id and display name
+        measurement = coordinator.data.measurements[index]
+        measurement_id = getattr(measurement, "id", index)
+        self._measurement_id = measurement_id
+        self._attr_unique_id = f"{coordinator.hub.mac}_measurement_{measurement_id}"
+        self._attr_name = getattr(measurement, "name", f"Measurement {measurement_id}")
 
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return (
-            self._measurement_data.get("name") or 
-            self._measurement_data.get("measurementName") or 
-            f"Measurement {self._measurement_id}"
-        )
+        # Set device class and unit from measurement type
+        mtype = str(getattr(measurement, "type", "")).lower()
+        for key, (device_class, unit) in _MEASUREMENT_TYPE_MAP.items():
+            if key in mtype:
+                self._attr_device_class = device_class
+                self._attr_native_unit_of_measurement = unit
+                break
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info."""
+        panel = self.coordinator.hub.panel
         return DeviceInfo(
-            identifiers={(DOMAIN, self._hub.mac)},
-            name=self._hub.panel.name if self._hub.panel else "Crow Shepherd",
+            identifiers={(DOMAIN, self.coordinator.hub.mac)},
+            name=panel.name,
             manufacturer="Crow",
-            model="Shepherd",
+            model=panel.firmware_version or "Alarm Panel",
+        )
+
+    def _get_measurement(self) -> Any | None:
+        """Return the current measurement object from coordinator data."""
+        return next(
+            (
+                m
+                for m in self.coordinator.data.measurements
+                if getattr(m, "id", None) == self._measurement_id
+            ),
+            None,
         )
 
     @property
-    def native_value(self) -> float | int | str | None:
+    def native_value(self) -> float | str | None:
         """Return the measurement value."""
-        value = self._measurement_data.get("value") or self._measurement_data.get("currentValue")
-        
+        measurement = self._get_measurement()
+        if measurement is None:
+            return None
+        value = getattr(measurement, "value", None)
         if value is None:
             return None
-        
         try:
-            # Try to return as number
             return float(value)
         except (ValueError, TypeError):
             return str(value)
@@ -128,99 +116,10 @@ class CrowShepherdMeasurementSensor(SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
-        attrs = {
+        measurement = self._get_measurement()
+        if measurement is None:
+            return {}
+        return {
             "measurement_id": self._measurement_id,
-            "measurement_type": self._measurement_data.get("type"),
+            "measurement_type": getattr(measurement, "type", None),
         }
-        
-        # Add zone info if available
-        zone_id = self._measurement_data.get("zoneId") or self._measurement_data.get("zone_id")
-        if zone_id:
-            attrs["zone_id"] = zone_id
-        
-        return attrs
-
-    async def async_update(self) -> None:
-        """Update measurement state."""
-        measurements = await self._hub.get_measurements()
-        
-        for measurement in measurements:
-            measurement_id = (
-                measurement.get("id") or 
-                measurement.get("measurementId") or 
-                measurement.get("_id")
-            )
-            if measurement_id == self._measurement_id:
-                self._measurement_data = measurement
-                break
-
-
-class CrowShepherdZoneBatterySensor(SensorEntity):
-    """Sensor showing zone battery level."""
-
-    _attr_has_entity_name = True
-    _attr_device_class = SensorDeviceClass.BATTERY
-    _attr_native_unit_of_measurement = "%"
-    _attr_state_class = SensorStateClass.MEASUREMENT
-
-    def __init__(self, hub: CrowHub, zone_data: dict[str, Any]) -> None:
-        """Initialize the sensor."""
-        self._hub = hub
-        self._zone_data = zone_data
-        self._zone_id = (
-            zone_data.get("id") or 
-            zone_data.get("zoneId") or 
-            zone_data.get("zone_id")
-        )
-        self._attr_unique_id = f"{hub.mac}_zone_{self._zone_id}_battery"
-
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        zone_name = (
-            self._zone_data.get("name") or 
-            self._zone_data.get("zoneName") or 
-            f"Zone {self._zone_id}"
-        )
-        return f"{zone_name} Battery"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._hub.mac)},
-            name=self._hub.panel.name if self._hub.panel else "Crow Shepherd",
-            manufacturer="Crow",
-            model="Shepherd",
-        )
-
-    @property
-    def native_value(self) -> int | None:
-        """Return the battery level."""
-        battery = (
-            self._zone_data.get("battery") or 
-            self._zone_data.get("batteryLevel") or 
-            self._zone_data.get("battery_level")
-        )
-        
-        if battery is None:
-            return None
-        
-        try:
-            return int(float(battery))
-        except (ValueError, TypeError):
-            return None
-
-    async def async_update(self) -> None:
-        """Update zone battery state."""
-        zones = await self._hub.get_devices()
-        
-        for zone in zones:
-            zone_id = (
-                zone.get("id") or 
-                zone.get("zoneId") or 
-                zone.get("zone_id")
-            )
-            if zone_id == self._zone_id:
-                self._zone_data = zone
-                break

--- a/custom_components/crow_shepherd/services.yaml
+++ b/custom_components/crow_shepherd/services.yaml
@@ -1,18 +1,16 @@
 bypass_zone:
   name: Bypass Zone
   description: Bypass or unbypass a zone on the alarm panel.
-  target:
-    entity:
-      integration: crow_shepherd
-      domain: alarm_control_panel
   fields:
     zone_id:
       name: Zone ID
-      description: The ID of the zone to bypass.
+      description: The numeric ID of the zone to bypass or unbypass.
       required: true
-      example: "1"
+      example: 1
       selector:
-        text:
+        number:
+          min: 1
+          mode: box
     bypass:
       name: Bypass
       description: True to bypass the zone, false to unbypass.
@@ -20,19 +18,3 @@ bypass_zone:
       default: true
       selector:
         boolean:
-
-trigger_camera_snapshot:
-  name: Trigger Camera Snapshot
-  description: Trigger a PIR camera zone to take a new snapshot.
-  target:
-    entity:
-      integration: crow_shepherd
-      domain: alarm_control_panel
-  fields:
-    zone_id:
-      name: Zone ID
-      description: The ID of the camera zone to trigger.
-      required: true
-      example: "1"
-      selector:
-        text:

--- a/custom_components/crow_shepherd/strings.json
+++ b/custom_components/crow_shepherd/strings.json
@@ -4,19 +4,21 @@
     "step": {
       "user": {
         "title": "Connect to Crow Cloud",
-        "description": "Enter your Crow Cloud account credentials and panel MAC address.",
+        "description": "Enter your Crow Cloud account credentials and the MAC address of your alarm panel.",
         "data": {
           "email": "Email",
           "password": "Password",
-          "panel_mac": "Panel MAC Address"
+          "panel_mac": "Panel MAC Address",
+          "panel_code": "Panel User Code (optional)"
         },
         "data_description": {
-          "panel_mac": "Enter with or without separators (e.g., AABBCCDDEEFF or AA:BB:CC:DD:EE:FF)"
+          "panel_mac": "Enter with or without separators — both 0013A1250A45 and 00:13:A1:25:0A:45 are accepted.",
+          "panel_code": "The numeric user code used to arm and disarm the panel. Leave blank if not required."
         }
       },
       "reauth_confirm": {
         "title": "Reauthentication Required",
-        "description": "The Crow Shepherd integration needs to re-authenticate your account.",
+        "description": "The Crow Shepherd integration needs to re-authenticate. Enter updated credentials below.",
         "data": {
           "email": "Email",
           "password": "Password"
@@ -24,79 +26,45 @@
       }
     },
     "error": {
-      "invalid_auth": "Invalid email or password",
-      "cannot_connect": "Failed to connect to Crow Cloud. Please check your internet connection.",
+      "invalid_auth": "Invalid email or password.",
+      "cannot_connect": "Failed to connect to Crow Cloud. Check your internet connection.",
       "no_panel": "No alarm panel found with the specified MAC address. Verify the MAC is correct.",
-      "invalid_mac": "Invalid MAC address format. Enter 12 hex characters (e.g., AABBCCDDEEFF or AA:BB:CC:DD:EE:FF)",
-      "unknown": "An unexpected error occurred"
+      "invalid_mac": "Invalid MAC address format. Enter 12 hex characters — e.g. 0013A1250A45 or 00:13:A1:25:0A:45.",
+      "unknown": "An unexpected error occurred."
     },
     "abort": {
-      "already_configured": "This panel is already configured",
-      "reauth_successful": "Reauthentication successful"
+      "already_configured": "This panel is already configured.",
+      "reauth_successful": "Reauthentication was successful."
     }
   },
   "options": {
     "step": {
       "init": {
         "title": "Crow Shepherd Options",
-        "description": "Configure the Crow Shepherd integration settings.",
+        "description": "Adjust integration settings.",
         "data": {
           "scan_interval": "Update interval (seconds)",
-          "panel_code": "Panel Code"
+          "panel_code": "Panel User Code"
+        },
+        "data_description": {
+          "scan_interval": "How often to poll the Crow Cloud for updates (10–300 seconds).",
+          "panel_code": "The numeric user code used to arm and disarm the panel. Leave blank if not required."
         }
-      }
-    }
-  },
-  "entity": {
-    "alarm_control_panel": {
-      "crow_shepherd": {
-        "name": "Alarm Panel"
-      }
-    },
-    "binary_sensor": {
-      "zone": {
-        "name": "{zone_name}"
-      }
-    },
-    "switch": {
-      "output": {
-        "name": "{output_name}"
-      }
-    },
-    "sensor": {
-      "last_event": {
-        "name": "Last Event"
-      },
-      "events_today": {
-        "name": "Events Today"
-      },
-      "zone_battery": {
-        "name": "{zone_name} Battery"
       }
     }
   },
   "services": {
     "bypass_zone": {
       "name": "Bypass Zone",
-      "description": "Bypass or unbypass a zone.",
+      "description": "Bypass or unbypass a zone on the alarm panel.",
       "fields": {
         "zone_id": {
           "name": "Zone ID",
-          "description": "The ID of the zone to bypass."
+          "description": "The numeric ID of the zone to bypass or unbypass."
         },
         "bypass": {
           "name": "Bypass",
           "description": "True to bypass, false to unbypass."
-        }
-      }
-    },
-    "trigger_camera_snapshot": {
-      "name": "Trigger Camera Snapshot",
-      "description": "Trigger a camera to take a new snapshot.",
-      "fields": {
-        "zone_id": {
-          "name": "Zone ID",
-          "description": "The ID of the camera zone."
         }
       }
     }

--- a/custom_components/crow_shepherd/switch.py
+++ b/custom_components/crow_shepherd/switch.py
@@ -4,14 +4,18 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from crow_security_ng.exceptions import ResponseError
+from crow_security_ng.models import Output
+
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DATA_HUB, DOMAIN, OUTPUT_STATE_ON
-from .hub import CrowHub
+from .const import DATA_COORDINATOR, DOMAIN
+from .coordinator import CrowShepherdCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,117 +25,104 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Crow Shepherd switches from config entry."""
-    hub: CrowHub = hass.data[DOMAIN][entry.entry_id][DATA_HUB]
-
-    entities: list[CrowShepherdOutputSwitch] = []
-
-    # Get outputs from the hub
-    outputs = await hub.get_outputs()
-    
-    for output in outputs:
-        output_id = output.get("id") or output.get("outputId") or output.get("output_id")
-        if output_id:
-            entities.append(CrowShepherdOutputSwitch(hub, output))
-
-    async_add_entities(entities)
+    """Set up switch entities from a config entry."""
+    coordinator: CrowShepherdCoordinator = hass.data[DOMAIN][entry.entry_id][
+        DATA_COORDINATOR
+    ]
+    async_add_entities(
+        CrowShepherdOutputSwitch(coordinator, output)
+        for output in coordinator.data.outputs
+    )
 
 
-class CrowShepherdOutputSwitch(SwitchEntity):
-    """Representation of a Crow Shepherd output switch."""
+class CrowShepherdOutputSwitch(
+    CoordinatorEntity[CrowShepherdCoordinator],
+    SwitchEntity,
+):
+    """Switch representing a Crow output."""
 
     _attr_has_entity_name = True
 
-    def __init__(self, hub: CrowHub, output_data: dict[str, Any]) -> None:
-        """Initialize the output switch."""
-        self._hub = hub
-        self._output_data = output_data
-        self._output_id = (
-            output_data.get("id") or 
-            output_data.get("outputId") or 
-            output_data.get("output_id")
-        )
-        self._attr_unique_id = f"{hub.mac}_output_{self._output_id}"
-
-    @property
-    def output_id(self) -> str:
-        """Return the output ID."""
-        return self._output_id
-
-    @property
-    def name(self) -> str:
-        """Return the name of the switch."""
-        return (
-            self._output_data.get("name") or 
-            self._output_data.get("outputName") or 
-            f"Output {self._output_id}"
-        )
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if the output is on."""
-        state = self._output_data.get("state") or self._output_data.get("status")
-        
-        if isinstance(state, bool):
-            return state
-        if isinstance(state, int):
-            return state == 1
-        if isinstance(state, str):
-            return state.lower() in (OUTPUT_STATE_ON, "1", "true", "active", "activated")
-        
-        return False
+    def __init__(
+        self,
+        coordinator: CrowShepherdCoordinator,
+        output: Output,
+    ) -> None:
+        """Initialise entity."""
+        super().__init__(coordinator)
+        self._output_id = output.id
+        self._attr_unique_id = f"{coordinator.hub.mac}_output_{output.id}"
+        self._attr_name = output.name
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info."""
+        panel = self.coordinator.hub.panel
         return DeviceInfo(
-            identifiers={(DOMAIN, self._hub.mac)},
-            name=self._hub.panel.name if self._hub.panel else "Crow Shepherd",
+            identifiers={(DOMAIN, self.coordinator.hub.mac)},
+            name=panel.name,
             manufacturer="Crow",
-            model="Shepherd",
+            model=panel.firmware_version or "Alarm Panel",
         )
+
+    def _get_output(self) -> Output | None:
+        """Return the current Output object from coordinator data."""
+        return next(
+            (o for o in self.coordinator.data.outputs if o.id == self._output_id),
+            None,
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the output is active.
+
+        Output.state is a bool in crow_security_ng.
+        """
+        output = self._get_output()
+        return output.state if output is not None else False
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
-        attrs = {
-            "output_id": self._output_id,
-            "output_name": self._output_data.get("name") or self._output_data.get("outputName"),
+        output = self._get_output()
+        if output is None:
+            return {}
+        return {
+            "output_id": output.id,
+            "output_type": output.output_type,
+            "tamper": output.tamper_alarm,
+            "battery_low": output.battery_low,
+            "rssi": output.rssi,
         }
-        
-        # Add output type if available
-        output_type = self._output_data.get("type") or self._output_data.get("outputType")
-        if output_type:
-            attrs["output_type"] = output_type
-        
-        return attrs
-
-    async def async_update(self) -> None:
-        """Update output state."""
-        outputs = await self._hub.get_outputs()
-        
-        for output in outputs:
-            output_id = (
-                output.get("id") or 
-                output.get("outputId") or 
-                output.get("output_id")
-            )
-            if output_id == self._output_id:
-                self._output_data = output
-                break
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the output on."""
-        _LOGGER.debug("Turning on output %s", self._output_id)
-        success = await self._hub.set_output_state(self._output_id, True)
-        if success:
-            self._output_data["state"] = True
-            self.async_write_ha_state()
+        await self._set_state(True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the output off."""
-        _LOGGER.debug("Turning off output %s", self._output_id)
-        success = await self._hub.set_output_state(self._output_id, False)
-        if success:
-            self._output_data["state"] = False
-            self.async_write_ha_state()
+        await self._set_state(False)
+
+    async def _set_state(self, state: bool) -> None:
+        """Send set-output-state command and refresh coordinator."""
+        try:
+            await self.coordinator.hub.panel.set_output_state(self._output_id, state)
+        except ResponseError as err:
+            _LOGGER.error(
+                "Output %s: API error %s setting state to %s: %s",
+                self._output_id,
+                err.status_code,
+                state,
+                err,
+            )
+            return
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error(
+                "Output %s: unexpected error setting state to %s: %s",
+                self._output_id,
+                state,
+                err,
+            )
+            return
+
+        await self.coordinator.async_request_refresh()

--- a/custom_components/crow_shepherd/translations/en.json
+++ b/custom_components/crow_shepherd/translations/en.json
@@ -4,19 +4,21 @@
     "step": {
       "user": {
         "title": "Connect to Crow Cloud",
-        "description": "Enter your Crow Cloud account credentials and panel MAC address.",
+        "description": "Enter your Crow Cloud account credentials and the MAC address of your alarm panel.",
         "data": {
           "email": "Email",
           "password": "Password",
-          "panel_mac": "Panel MAC Address"
+          "panel_mac": "Panel MAC Address",
+          "panel_code": "Panel User Code (optional)"
         },
         "data_description": {
-          "panel_mac": "Enter with or without separators (e.g., AABBCCDDEEFF or AA:BB:CC:DD:EE:FF)"
+          "panel_mac": "Enter with or without separators — both 0013A1250A45 and 00:13:A1:25:0A:45 are accepted.",
+          "panel_code": "The numeric user code used to arm and disarm the panel. Leave blank if not required."
         }
       },
       "reauth_confirm": {
         "title": "Reauthentication Required",
-        "description": "The Crow Shepherd integration needs to re-authenticate your account.",
+        "description": "The Crow Shepherd integration needs to re-authenticate. Enter updated credentials below.",
         "data": {
           "email": "Email",
           "password": "Password"
@@ -24,79 +26,45 @@
       }
     },
     "error": {
-      "invalid_auth": "Invalid email or password",
-      "cannot_connect": "Failed to connect to Crow Cloud. Please check your internet connection.",
+      "invalid_auth": "Invalid email or password.",
+      "cannot_connect": "Failed to connect to Crow Cloud. Check your internet connection.",
       "no_panel": "No alarm panel found with the specified MAC address. Verify the MAC is correct.",
-      "invalid_mac": "Invalid MAC address format. Enter 12 hex characters (e.g., AABBCCDDEEFF or AA:BB:CC:DD:EE:FF)",
-      "unknown": "An unexpected error occurred"
+      "invalid_mac": "Invalid MAC address format. Enter 12 hex characters — e.g. 0013A1250A45 or 00:13:A1:25:0A:45.",
+      "unknown": "An unexpected error occurred."
     },
     "abort": {
-      "already_configured": "This panel is already configured",
-      "reauth_successful": "Reauthentication successful"
+      "already_configured": "This panel is already configured.",
+      "reauth_successful": "Reauthentication was successful."
     }
   },
   "options": {
     "step": {
       "init": {
         "title": "Crow Shepherd Options",
-        "description": "Configure the Crow Shepherd integration settings.",
+        "description": "Adjust integration settings.",
         "data": {
           "scan_interval": "Update interval (seconds)",
-          "panel_code": "Panel Code"
+          "panel_code": "Panel User Code"
+        },
+        "data_description": {
+          "scan_interval": "How often to poll the Crow Cloud for updates (10–300 seconds).",
+          "panel_code": "The numeric user code used to arm and disarm the panel. Leave blank if not required."
         }
-      }
-    }
-  },
-  "entity": {
-    "alarm_control_panel": {
-      "crow_shepherd": {
-        "name": "Alarm Panel"
-      }
-    },
-    "binary_sensor": {
-      "zone": {
-        "name": "{zone_name}"
-      }
-    },
-    "switch": {
-      "output": {
-        "name": "{output_name}"
-      }
-    },
-    "sensor": {
-      "last_event": {
-        "name": "Last Event"
-      },
-      "events_today": {
-        "name": "Events Today"
-      },
-      "zone_battery": {
-        "name": "{zone_name} Battery"
       }
     }
   },
   "services": {
     "bypass_zone": {
       "name": "Bypass Zone",
-      "description": "Bypass or unbypass a zone.",
+      "description": "Bypass or unbypass a zone on the alarm panel.",
       "fields": {
         "zone_id": {
           "name": "Zone ID",
-          "description": "The ID of the zone to bypass."
+          "description": "The numeric ID of the zone to bypass or unbypass."
         },
         "bypass": {
           "name": "Bypass",
           "description": "True to bypass, false to unbypass."
-        }
-      }
-    },
-    "trigger_camera_snapshot": {
-      "name": "Trigger Camera Snapshot",
-      "description": "Trigger a camera to take a new snapshot.",
-      "fields": {
-        "zone_id": {
-          "name": "Zone ID",
-          "description": "The ID of the camera zone."
         }
       }
     }


### PR DESCRIPTION
## Summary

- **New `coordinator.py`**: Replaces per-entity `async_update` calls and the manual Throttle hub with a single `DataUpdateCoordinator`. All entity data (areas, zones, outputs, measurements) is fetched in one place and entities consume it via `CoordinatorEntity`.
- **Typed state enums**: `AlarmControlPanelState` enum used throughout (HA 2024.11+). Single authoritative `_AREA_STATE_MAP` in `alarm_control_panel.py` — duplicate string maps removed from `const.py`.
- **Correct data model usage**: `Zone.state` and `Output.state` are `bool` in `crow_security_ng` — the old code treated them as strings with multi-field fallback chains. Fixed.
- **Solid MAC validation**: Config flow uses `crow_security_ng.normalize_mac()` directly, accepting both `0013A1250A45` and `00:13:A1:25:0A:45` (and dash/space variants). Unique ID is MAC only, not `email+mac`.
- **Panel code wired correctly**: `hub.py` sets `panel.user_code` after connecting so arm/disarm API headers are sent automatically. `panel_code` is now offered in the initial setup wizard step (not just options).
- **Implemented `bypass_zone` service**: Calls `panel.set_zone_bypass(zone_id, bypass)` — was declared but never implemented.
- **WebSocket reconnect loop**: Runs as a background task, reconnects every 30 s after any failure, and is cleanly cancelled on entry unload.
- **Removed broken code**: `CrowShepherdZoneBatterySensor` (battery_low is a `bool`, not a percentage), `trigger_camera_snapshot` service (undeclared in library).
- **Bumped requirement**: `crow_security_ng>=0.1.8`, version `0.1.0`.

## Test plan

- [ ] Add integration via UI — enter MAC as `0013A1250A45` → succeeds
- [ ] Add integration via UI — enter MAC as `00:13:A1:25:0A:45` → succeeds (same unique ID)
- [ ] Enter invalid MAC (e.g. `ZZZZZZZZZZZZ`) → shows `invalid_mac` error
- [ ] Verify `alarm_control_panel`, `binary_sensor`, `switch` entities appear with correct states after setup
- [ ] Arm away / arm home / disarm from HA UI → panel responds
- [ ] Open a zone physically → HA binary sensor flips within poll interval (or sooner via WebSocket)
- [ ] Call `crow_shepherd.bypass_zone` with a valid zone_id → zone shows bypassed in attributes
- [ ] Restart HA → integration reconnects cleanly without errors in the log
- [ ] Change options (scan_interval / panel_code) → entry reloads and picks up new values

🤖 Generated with [Claude Code](https://claude.com/claude-code)