### PR TITLE
v0.2.1: PIR camera snapshot support (image platform)

### DIFF
--- a/custom_components/crow_shepherd/const.py
+++ b/custom_components/crow_shepherd/const.py
@@ -17,8 +17,9 @@ DEFAULT_SCAN_INTERVAL: Final = 30
 PLATFORMS: Final = [
     "alarm_control_panel",
     "binary_sensor",
-    "switch",
+    "image",
     "sensor",
+    "switch",
 ]
 
 # hass.data keys

--- a/custom_components/crow_shepherd/image.py
+++ b/custom_components/crow_shepherd/image.py
@@ -1,0 +1,139 @@
+"""Image platform for Crow Shepherd PIR camera zones."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from crow_security_ng.models import Zone
+
+from homeassistant.components.image import ImageEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import (
+    AddEntitiesCallback,
+    async_get_current_platform,
+)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from .const import DATA_COORDINATOR, DOMAIN
+from .coordinator import CrowShepherdCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up image entities from a config entry."""
+    coordinator: CrowShepherdCoordinator = hass.data[DOMAIN][entry.entry_id][
+        DATA_COORDINATOR
+    ]
+    entities = [
+        CrowShepherdCameraImage(coordinator, zone)
+        for zone in coordinator.data.zones
+        if zone.is_camera
+    ]
+    async_add_entities(entities)
+
+    platform = async_get_current_platform()
+    platform.async_register_entity_service(
+        "fetch_camera_snapshot",
+        {},
+        "async_fetch_snapshot",
+    )
+
+
+class CrowShepherdCameraImage(
+    CoordinatorEntity[CrowShepherdCoordinator],
+    ImageEntity,
+):
+    """Image entity showing the latest on-demand snapshot from a PIR camera zone."""
+
+    _attr_has_entity_name = True
+    _attr_content_type = "image/jpeg"
+
+    def __init__(
+        self,
+        coordinator: CrowShepherdCoordinator,
+        zone: Zone,
+    ) -> None:
+        """Initialise entity."""
+        super().__init__(coordinator)
+        self._zone_id = zone.id
+        self._attr_unique_id = f"{coordinator.hub.mac}_zone_{zone.id}_image"
+        self._attr_name = f"{zone.name} Snapshot"
+        self._image_bytes: bytes | None = None
+        self._image_last_updated: datetime | None = None
+        self._last_picture_id: int | None = None
+        self._last_picture_type: str | None = None
+        self._last_panel_time: str | None = None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Group under the panel device."""
+        panel = self.coordinator.hub.panel
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.hub.mac)},
+            name=panel.name,
+            manufacturer="Crow",
+            model=panel.firmware_version or "Alarm Panel",
+        )
+
+    @property
+    def image_last_updated(self) -> datetime | None:
+        """Return when the stored image was last fetched."""
+        return self._image_last_updated
+
+    async def async_image(self) -> bytes | None:
+        """Return the stored JPEG bytes."""
+        return self._image_bytes
+
+    async def async_fetch_snapshot(self) -> None:
+        """Fetch the latest snapshot from the panel and store it.
+
+        Called by the crow_shepherd.fetch_camera_snapshot action.
+        """
+        try:
+            pics = await self.coordinator.hub.panel.get_zone_pictures(self._zone_id)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error("Zone %s: could not list pictures: %s", self._zone_id, err)
+            return
+
+        if not pics:
+            _LOGGER.warning("Zone %s: no pictures available yet", self._zone_id)
+            return
+
+        pic = pics[-1]
+
+        try:
+            self._image_bytes = await self.coordinator.hub.session.get_picture_bytes(pic)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error(
+                "Zone %s: could not download picture %s: %s",
+                self._zone_id,
+                pic.id,
+                err,
+            )
+            return
+
+        self._image_last_updated = pic.created or dt_util.utcnow()
+        self._last_picture_id = pic.id
+        self._last_picture_type = "alarm" if pic.picture_type == 1 else "manual"
+        self._last_panel_time = pic.panel_time.isoformat() if pic.panel_time else None
+        self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        if self._last_picture_id is None:
+            return {}
+        return {
+            "picture_id": self._last_picture_id,
+            "picture_type": self._last_picture_type,
+            "panel_time": self._last_panel_time,
+        }

--- a/custom_components/crow_shepherd/manifest.json
+++ b/custom_components/crow_shepherd/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/tubalainen/crow_shepherd",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/tubalainen/crow_shepherd/issues",
-  "requirements": ["crow_security_ng>=0.2.0"],
-  "version": "0.2.0",
+  "requirements": ["crow_security_ng>=0.2.1"],
+  "version": "0.2.1",
   "integration_type": "hub"
 }

--- a/custom_components/crow_shepherd/services.yaml
+++ b/custom_components/crow_shepherd/services.yaml
@@ -1,3 +1,11 @@
+fetch_camera_snapshot:
+  name: Fetch camera snapshot
+  description: Downloads the latest snapshot from a PIR camera zone and updates the image entity.
+  target:
+    entity:
+      integration: crow_shepherd
+      domain: image
+
 bypass_zone:
   name: Bypass Zone
   description: Bypass or unbypass a zone on the alarm panel.

--- a/custom_components/crow_shepherd/strings.json
+++ b/custom_components/crow_shepherd/strings.json
@@ -54,6 +54,10 @@
     }
   },
   "services": {
+    "fetch_camera_snapshot": {
+      "name": "Fetch camera snapshot",
+      "description": "Downloads the latest snapshot from a PIR camera zone and updates the image entity."
+    },
     "bypass_zone": {
       "name": "Bypass Zone",
       "description": "Bypass or unbypass a zone on the alarm panel.",

--- a/custom_components/crow_shepherd/translations/en.json
+++ b/custom_components/crow_shepherd/translations/en.json
@@ -54,6 +54,10 @@
     }
   },
   "services": {
+    "fetch_camera_snapshot": {
+      "name": "Fetch camera snapshot",
+      "description": "Downloads the latest snapshot from a PIR camera zone and updates the image entity."
+    },
     "bypass_zone": {
       "name": "Bypass Zone",
       "description": "Bypass or unbypass a zone on the alarm panel.",


### PR DESCRIPTION
## Summary

- **New `image` platform** — adds a `CrowShepherdCameraImage` entity for each zone where `zone.is_camera` is `True` (zone type 55 / smart-cam). Entity name: *"[Zone Name] Snapshot"*.
- **On-demand only** — no automatic polling. The image entity starts empty and is populated by explicitly calling the new action.
- **New action `crow_shepherd.fetch_camera_snapshot`** — entity service registered on the image platform. Calling it on a camera image entity fetches the latest snapshot from the panel via `Session.get_picture_bytes()` and stores the JPEG bytes in-memory. The HA frontend refreshes the image automatically via `image_last_updated`.
- **Attributes** — `picture_id`, `picture_type` (`alarm` / `manual`), `panel_time`.
- **Motion binary sensor unaffected** — camera zones keep their existing motion binary sensor alongside the new image entity.
- Bumps requirement to `crow_security_ng>=0.2.1`, version to `0.2.1`.

## Usage

```yaml
action: crow_shepherd.fetch_camera_snapshot
target:
  entity_id: image.hall_cam_snapshot
```

## Test plan

- [ ] Restart HA — confirm each camera zone gets a *"… Snapshot"* image entity with no image initially
- [ ] Call `crow_shepherd.fetch_camera_snapshot` targeting the entity — confirm image populates
- [ ] Check `image_last_updated` matches `picture.created` from the panel
- [ ] Confirm `picture_type` attribute shows `"alarm"` or `"manual"` correctly
- [ ] Call the action again — confirm image refreshes with the latest snapshot
- [ ] Confirm motion binary sensor for the same zone still works
- [ ] Confirm non-camera zones have no image entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)