### PR TITLE
Update repository references and Home Assistant version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A Home Assistant custom integration for Crow alarm panels that connects to Crow 
 
 1. Open HACS in Home Assistant
 2. Click **Integrations** → three-dot menu → **Custom repositories**
-3. Add this repository URL with category **Integration**
+3. Add `https://github.com/tubalainen/crow_security` with category **Integration**
 4. Install and restart Home Assistant
 
 ### Manual

--- a/custom_components/crow_shepherd/manifest.json
+++ b/custom_components/crow_shepherd/manifest.json
@@ -3,9 +3,9 @@
   "name": "Crow Shepherd Alarm",
   "codeowners": ["@tubalainen"],
   "config_flow": true,
-  "documentation": "https://github.com/tubalainen/crow_shepherd",
+  "documentation": "https://github.com/tubalainen/crow_security",
   "iot_class": "cloud_push",
-  "issue_tracker": "https://github.com/tubalainen/crow_shepherd/issues",
+  "issue_tracker": "https://github.com/tubalainen/crow_security/issues",
   "requirements": ["crow_security_ng>=0.2.1"],
   "version": "0.2.1",
   "integration_type": "hub"

--- a/hacs.json
+++ b/hacs.json
@@ -1,8 +1,4 @@
 {
   "name": "Crow Shepherd Alarm",
-  "hacs": "1.6.0",
-  "homeassistant": "2024.1.0",
-  "render_readme": true,
-  "zip_release": true,
-  "filename": "crow_shepherd.zip"
+  "homeassistant": "2024.11.0"
 }


### PR DESCRIPTION
## Summary
This PR updates the integration configuration to reflect a repository rename from `crow_shepherd` to `crow_security` and modernizes the Home Assistant version requirement.

## Key Changes
- **Repository rename**: Updated all GitHub repository references from `tubalainen/crow_shepherd` to `tubalainen/crow_security` in:
  - `manifest.json` (documentation and issue tracker URLs)
  - `README.md` (installation instructions)
- **Home Assistant version**: Updated minimum required version from `2024.1.0` to `2024.11.0`
- **HACS configuration cleanup**: Removed deprecated HACS-specific fields (`hacs`, `render_readme`, `zip_release`, `filename`) from `hacs.json`, keeping only essential metadata

## Notable Details
- The integration name and functionality remain unchanged
- All other manifest fields and requirements are preserved
- The version number stays at `0.2.1`

https://claude.ai/code/session_01QEDeNhwe1ALgyCTqYBhPKA