### PR TITLE
fix: harden options flow and add startup warning for camera zones

### DIFF
--- a/custom_components/crow_shepherd/config_flow.py
+++ b/custom_components/crow_shepherd/config_flow.py
@@ -212,13 +212,19 @@ class CrowShepherdOptionsFlow(OptionsFlow):
         )
 
         # Build zone list from live coordinator data for the multi-select
-        coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id][
-            DATA_COORDINATOR
-        ]
-        zone_options = [
-            selector.SelectOptionDict(value=str(zone.id), label=zone.name)
-            for zone in sorted(coordinator.data.zones, key=lambda z: z.name)
-        ]
+        try:
+            coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id][
+                DATA_COORDINATOR
+            ]
+            zone_options = [
+                selector.SelectOptionDict(value=str(zone.id), label=zone.name)
+                for zone in sorted(coordinator.data.zones, key=lambda z: z.name)
+            ]
+        except (KeyError, AttributeError):
+            _LOGGER.warning(
+                "Could not load zone list for options form — coordinator not ready"
+            )
+            zone_options = []
         current_camera_ids = [
             str(x)
             for x in self.config_entry.options.get(CONF_CAMERA_ZONE_IDS, [])

--- a/custom_components/crow_shepherd/image.py
+++ b/custom_components/crow_shepherd/image.py
@@ -41,6 +41,14 @@ async def async_setup_entry(
     ]
     async_add_entities(entities)
 
+    if not entities:
+        _LOGGER.warning(
+            "No PIR camera image entities created. "
+            "If your panel has PIR cameras, go to Settings \u2192 Devices & Services "
+            "\u2192 Crow Shepherd \u2192 Configure and select the camera zones under "
+            "'PIR Camera Zones', then reload the integration."
+        )
+
     platform = async_get_current_platform()
     platform.async_register_entity_service(
         "fetch_camera_snapshot",


### PR DESCRIPTION
## Problem

Two issues found in the camera zone configuration added in PR #8:

1. **Options form crash** — coordinator access (`hass.data[DOMAIN][entry_id][DATA_COORDINATOR]`) has no error handling. If the coordinator isn't ready at the exact moment the user opens Configure, the form throws a `KeyError`/`AttributeError` and never renders — meaning the user can't pick camera zones and no image entities are ever created.

2. **No user guidance** — if no camera zones are configured, no image entities appear, but there's no log message to tell the user why or what to do.

## Fix

- **`config_flow.py`**: wrap coordinator access in `try/except (KeyError, AttributeError)`, falling back to an empty zone list so the form always renders
- **`image.py`**: emit a `WARNING` log when `async_setup_entry` creates zero image entities, with clear instructions pointing to Configure → PIR Camera Zones

## Test plan

- [ ] With PR #8 code but no camera zones configured, check HA log — should now see the WARNING guiding user to Configure
- [ ] Open Configure while integration is loading (unlikely timing, but) — form should still open, zone list may be empty
- [ ] Select camera zones, save, reload — `image.*` entities appear, WARNING log disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)