### PR TITLE
feat: image entities for all zones with auto-fetch on startup (v0.2.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Home Assistant custom integration for Crow alarm panels that connects to Crow 
 - **Zone Binary Sensors** — open/close state for every zone with motion, tamper, bypass, battery, RSSI and battery voltage as attributes
 - **Output Switches** — turn outputs on/off with tamper, battery, RSSI and battery voltage as attributes
 - **DECT Measurement Sensors** — temperature, humidity, air pressure and gas level sensors for smart devices
-- **PIR Camera Image Entities** — on-demand JPEG snapshots from smart-cam zones (zone type 55), fetched via the `fetch_camera_snapshot` action
+- **PIR Camera Image Entities** — one `image.*` entity per zone; automatically pre-populated with the most recent stored snapshot on startup; refresh on demand via the `fetch_camera_snapshot` action
 
 ## Requirements
 
@@ -101,15 +101,17 @@ One entity per measurement type per smart device:
 | `sensor.<device_name>_air_pressure` | Atmospheric pressure (hPa) |
 | `sensor.<device_name>_gas_level` | Gas level (0–4 scale) |
 
-### Image Entities (PIR cameras)
+### Image Entities
 
-One entity per camera zone (`zone_type == 55`):
+One entity per zone — no manual configuration needed:
 
 | Entity | Description |
 |--------|-------------|
-| `image.<zone_name>_snapshot` | Latest on-demand JPEG snapshot |
+| `image.<zone_name>_snapshot` | Latest JPEG snapshot |
 
-The entity starts empty. Call `crow_shepherd.fetch_camera_snapshot` targeting it to populate the image.
+On every integration startup, each entity is silently pre-populated with the most recent stored picture from the panel. Zones that have no pictures yet remain empty without generating warnings.
+
+To fetch a fresh picture after a PIR trigger, call `crow_shepherd.fetch_camera_snapshot`.
 
 **Attributes:** `picture_id`, `picture_type` (`alarm` / `manual`), `panel_time`
 

--- a/custom_components/crow_shepherd/config_flow.py
+++ b/custom_components/crow_shepherd/config_flow.py
@@ -23,14 +23,11 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import callback
-from homeassistant.helpers import selector
 
 from .const import (
-    CONF_CAMERA_ZONE_IDS,
     CONF_PANEL_CODE,
     CONF_PANEL_MAC,
     CONF_SCAN_INTERVAL,
-    DATA_COORDINATOR,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -199,10 +196,6 @@ class CrowShepherdOptionsFlow(OptionsFlow):
             # Strip empty panel_code so we don't store an empty string
             if not user_input.get(CONF_PANEL_CODE, "").strip():
                 user_input.pop(CONF_PANEL_CODE, None)
-            # SelectSelector returns strings — convert zone IDs back to ints
-            user_input[CONF_CAMERA_ZONE_IDS] = [
-                int(x) for x in user_input.get(CONF_CAMERA_ZONE_IDS, [])
-            ]
             return self.async_create_entry(title="", data=user_input)
 
         current_code = (
@@ -210,25 +203,6 @@ class CrowShepherdOptionsFlow(OptionsFlow):
             or self.config_entry.data.get(CONF_PANEL_CODE)
             or ""
         )
-
-        # Build zone list from live coordinator data for the multi-select
-        try:
-            coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id][
-                DATA_COORDINATOR
-            ]
-            zone_options = [
-                selector.SelectOptionDict(value=str(zone.id), label=zone.name)
-                for zone in sorted(coordinator.data.zones, key=lambda z: z.name)
-            ]
-        except (KeyError, AttributeError):
-            _LOGGER.warning(
-                "Could not load zone list for options form — coordinator not ready"
-            )
-            zone_options = []
-        current_camera_ids = [
-            str(x)
-            for x in self.config_entry.options.get(CONF_CAMERA_ZONE_IDS, [])
-        ]
 
         return self.async_show_form(
             step_id="init",
@@ -244,15 +218,6 @@ class CrowShepherdOptionsFlow(OptionsFlow):
                         CONF_PANEL_CODE,
                         default=current_code,
                     ): str,
-                    vol.Optional(
-                        CONF_CAMERA_ZONE_IDS,
-                        default=current_camera_ids,
-                    ): selector.SelectSelector(
-                        selector.SelectSelectorConfig(
-                            options=zone_options,
-                            multiple=True,
-                        )
-                    ),
                 }
             ),
         )

--- a/custom_components/crow_shepherd/const.py
+++ b/custom_components/crow_shepherd/const.py
@@ -9,7 +9,6 @@ DOMAIN: Final = "crow_shepherd"
 CONF_PANEL_MAC: Final = "panel_mac"
 CONF_PANEL_CODE: Final = "panel_code"
 CONF_SCAN_INTERVAL: Final = "scan_interval"
-CONF_CAMERA_ZONE_IDS: Final = "camera_zone_ids"
 
 # Default values
 DEFAULT_SCAN_INTERVAL: Final = 30

--- a/custom_components/crow_shepherd/image.py
+++ b/custom_components/crow_shepherd/image.py
@@ -1,6 +1,7 @@
 """Image platform for Crow Shepherd PIR camera zones."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime
 from typing import Any
@@ -18,7 +19,7 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_CAMERA_ZONE_IDS, DATA_COORDINATOR, DOMAIN
+from .const import DATA_COORDINATOR, DOMAIN
 from .coordinator import CrowShepherdCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,21 +34,18 @@ async def async_setup_entry(
     coordinator: CrowShepherdCoordinator = hass.data[DOMAIN][entry.entry_id][
         DATA_COORDINATOR
     ]
-    camera_zone_ids: set[int] = set(entry.options.get(CONF_CAMERA_ZONE_IDS, []))
     entities = [
         CrowShepherdCameraImage(coordinator, zone)
         for zone in coordinator.data.zones
-        if zone.is_camera or zone.id in camera_zone_ids
     ]
     async_add_entities(entities)
 
-    if not entities:
-        _LOGGER.warning(
-            "No PIR camera image entities created. "
-            "If your panel has PIR cameras, go to Settings \u2192 Devices & Services "
-            "\u2192 Crow Shepherd \u2192 Configure and select the camera zones under "
-            "'PIR Camera Zones', then reload the integration."
-        )
+    # Pre-populate entities with the most recent stored picture on startup.
+    # Zones with no pictures are skipped silently.
+    await asyncio.gather(
+        *(entity.async_fetch_snapshot(silent=True) for entity in entities),
+        return_exceptions=True,
+    )
 
     platform = async_get_current_platform()
     platform.async_register_entity_service(
@@ -102,10 +100,11 @@ class CrowShepherdCameraImage(
         """Return the stored JPEG bytes."""
         return self._image_bytes
 
-    async def async_fetch_snapshot(self) -> None:
+    async def async_fetch_snapshot(self, *, silent: bool = False) -> None:
         """Fetch the latest snapshot from the panel and store it.
 
-        Called by the crow_shepherd.fetch_camera_snapshot action.
+        Called by the crow_shepherd.fetch_camera_snapshot action, and also
+        automatically on integration startup (with silent=True).
         """
         try:
             pics = await self.coordinator.hub.panel.get_zone_pictures(self._zone_id)
@@ -114,7 +113,8 @@ class CrowShepherdCameraImage(
             return
 
         if not pics:
-            _LOGGER.warning("Zone %s: no pictures available yet", self._zone_id)
+            if not silent:
+                _LOGGER.warning("Zone %s: no pictures available yet", self._zone_id)
             return
 
         pic = pics[-1]

--- a/custom_components/crow_shepherd/manifest.json
+++ b/custom_components/crow_shepherd/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/tubalainen/crow_security/issues",
   "requirements": ["crow_security_ng>=0.2.1"],
-  "version": "0.2.2",
+  "version": "0.2.3",
   "integration_type": "hub"
 }

--- a/custom_components/crow_shepherd/strings.json
+++ b/custom_components/crow_shepherd/strings.json
@@ -44,13 +44,11 @@
         "description": "Adjust integration settings.",
         "data": {
           "scan_interval": "Update interval (seconds)",
-          "panel_code": "Panel User Code",
-          "camera_zone_ids": "PIR Camera Zones"
+          "panel_code": "Panel User Code"
         },
         "data_description": {
           "scan_interval": "How often to poll the Crow Cloud for updates (10–300 seconds).",
-          "panel_code": "The numeric user code used to arm and disarm the panel. Leave blank if not required.",
-          "camera_zone_ids": "Select zones that are PIR cameras. An image entity will be created for each selected zone."
+          "panel_code": "The numeric user code used to arm and disarm the panel. Leave blank if not required."
         }
       }
     }

--- a/custom_components/crow_shepherd/translations/en.json
+++ b/custom_components/crow_shepherd/translations/en.json
@@ -44,13 +44,11 @@
         "description": "Adjust integration settings.",
         "data": {
           "scan_interval": "Update interval (seconds)",
-          "panel_code": "Panel User Code",
-          "camera_zone_ids": "PIR Camera Zones"
+          "panel_code": "Panel User Code"
         },
         "data_description": {
           "scan_interval": "How often to poll the Crow Cloud for updates (10–300 seconds).",
-          "panel_code": "The numeric user code used to arm and disarm the panel. Leave blank if not required.",
-          "camera_zone_ids": "Select zones that are PIR cameras. An image entity will be created for each selected zone."
+          "panel_code": "The numeric user code used to arm and disarm the panel. Leave blank if not required."
         }
       }
     }


### PR DESCRIPTION
## Summary
- `image.*` entities are now created for **every zone** automatically — no manual "PIR Camera Zones" selection in Options needed
- On integration startup, the most recent stored picture is silently fetched for each zone; zones with no pictures are skipped without log warnings
- `crow_shepherd.fetch_camera_snapshot` action is unchanged — call it to get a fresh snapshot after a PIR trigger
- Remove `CONF_CAMERA_ZONE_IDS` and the PIR Camera Zones multi-select from the Options flow entirely

## Test plan
- [ ] Restart HA after deploying — all zones appear as `image.*` entities with no Options configuration required
- [ ] Zones that have stored pictures show the image immediately after startup
- [ ] Zones without pictures remain empty with no warnings in the HA log
- [ ] Options gear icon opens without error (no camera zone selector present)
- [ ] Calling `crow_shepherd.fetch_camera_snapshot` on a camera zone entity updates the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)