### PR TITLE
fix: restore camera zone selector and fix image entity crashes (v0.2.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Home Assistant custom integration for Crow alarm panels that connects to Crow 
 - **Zone Binary Sensors** — open/close state for every zone with motion, tamper, bypass, battery, RSSI and battery voltage as attributes
 - **Output Switches** — turn outputs on/off with tamper, battery, RSSI and battery voltage as attributes
 - **DECT Measurement Sensors** — temperature, humidity, air pressure and gas level sensors for smart devices
-- **PIR Camera Image Entities** — one `image.*` entity per zone; automatically pre-populated with the most recent stored snapshot on startup; refresh on demand via the `fetch_camera_snapshot` action
+- **PIR Camera Image Entities** — one `image.*` entity per configured camera zone; automatically pre-populated with the most recent stored snapshot on startup; refresh on demand via the `fetch_camera_snapshot` action
 
 ## Requirements
 
@@ -101,15 +101,15 @@ One entity per measurement type per smart device:
 | `sensor.<device_name>_air_pressure` | Atmospheric pressure (hPa) |
 | `sensor.<device_name>_gas_level` | Gas level (0–4 scale) |
 
-### Image Entities
+### Image Entities (PIR cameras)
 
-One entity per zone — no manual configuration needed:
+One entity per configured camera zone:
 
 | Entity | Description |
 |--------|-------------|
 | `image.<zone_name>_snapshot` | Latest JPEG snapshot |
 
-On every integration startup, each entity is silently pre-populated with the most recent stored picture from the panel. Zones that have no pictures yet remain empty without generating warnings.
+Select which zones are PIR cameras via **Settings → Devices & Services → Crow Shepherd → Configure** (gear icon) under **PIR Camera Zones**. On every integration startup, each image entity is automatically pre-populated with the most recent stored picture from the panel. Zones that have no pictures yet remain empty without generating log warnings.
 
 To fetch a fresh picture after a PIR trigger, call `crow_shepherd.fetch_camera_snapshot`.
 

--- a/custom_components/crow_shepherd/__init__.py
+++ b/custom_components/crow_shepherd/__init__.py
@@ -124,7 +124,7 @@ async def _ws_loop(hass: HomeAssistant, entry_id: str) -> None:
 
         async def _on_ws_message(msg: dict) -> None:
             _LOGGER.debug("WebSocket message received: %s", msg)
-            coordinator.async_request_refresh()
+            hass.async_create_task(coordinator.async_request_refresh())
 
         try:
             _LOGGER.debug("Starting WebSocket connection for panel %s", hub.mac)

--- a/custom_components/crow_shepherd/config_flow.py
+++ b/custom_components/crow_shepherd/config_flow.py
@@ -23,11 +23,14 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import callback
+from homeassistant.helpers import selector
 
 from .const import (
+    CONF_CAMERA_ZONE_IDS,
     CONF_PANEL_CODE,
     CONF_PANEL_MAC,
     CONF_SCAN_INTERVAL,
+    DATA_COORDINATOR,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -177,15 +180,11 @@ class CrowShepherdConfigFlow(ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Return the options flow handler."""
-        return CrowShepherdOptionsFlow(config_entry)
+        return CrowShepherdOptionsFlow()
 
 
 class CrowShepherdOptionsFlow(OptionsFlow):
-    """Options flow — update scan interval and panel code."""
-
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialise options flow."""
-        self.config_entry = config_entry
+    """Options flow — update scan interval, panel code, and camera zones."""
 
     async def async_step_init(
         self,
@@ -196,6 +195,10 @@ class CrowShepherdOptionsFlow(OptionsFlow):
             # Strip empty panel_code so we don't store an empty string
             if not user_input.get(CONF_PANEL_CODE, "").strip():
                 user_input.pop(CONF_PANEL_CODE, None)
+            # SelectSelector returns strings — convert zone IDs back to ints
+            user_input[CONF_CAMERA_ZONE_IDS] = [
+                int(x) for x in user_input.get(CONF_CAMERA_ZONE_IDS, [])
+            ]
             return self.async_create_entry(title="", data=user_input)
 
         current_code = (
@@ -203,6 +206,25 @@ class CrowShepherdOptionsFlow(OptionsFlow):
             or self.config_entry.data.get(CONF_PANEL_CODE)
             or ""
         )
+
+        # Build zone list from live coordinator data for the multi-select
+        try:
+            coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id][
+                DATA_COORDINATOR
+            ]
+            zone_options = [
+                selector.SelectOptionDict(value=str(zone.id), label=zone.name)
+                for zone in sorted(coordinator.data.zones, key=lambda z: z.name)
+            ]
+        except (KeyError, AttributeError):
+            _LOGGER.warning(
+                "Could not load zone list for options form — coordinator not ready"
+            )
+            zone_options = []
+        current_camera_ids = [
+            str(x)
+            for x in self.config_entry.options.get(CONF_CAMERA_ZONE_IDS, [])
+        ]
 
         return self.async_show_form(
             step_id="init",
@@ -218,6 +240,15 @@ class CrowShepherdOptionsFlow(OptionsFlow):
                         CONF_PANEL_CODE,
                         default=current_code,
                     ): str,
+                    vol.Optional(
+                        CONF_CAMERA_ZONE_IDS,
+                        default=current_camera_ids,
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=zone_options,
+                            multiple=True,
+                        )
+                    ),
                 }
             ),
         )

--- a/custom_components/crow_shepherd/const.py
+++ b/custom_components/crow_shepherd/const.py
@@ -9,6 +9,7 @@ DOMAIN: Final = "crow_shepherd"
 CONF_PANEL_MAC: Final = "panel_mac"
 CONF_PANEL_CODE: Final = "panel_code"
 CONF_SCAN_INTERVAL: Final = "scan_interval"
+CONF_CAMERA_ZONE_IDS: Final = "camera_zone_ids"
 
 # Default values
 DEFAULT_SCAN_INTERVAL: Final = 30

--- a/custom_components/crow_shepherd/image.py
+++ b/custom_components/crow_shepherd/image.py
@@ -1,7 +1,6 @@
 """Image platform for Crow Shepherd PIR camera zones."""
 from __future__ import annotations
 
-import asyncio
 import logging
 from datetime import datetime
 from typing import Any
@@ -19,7 +18,7 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from .const import DATA_COORDINATOR, DOMAIN
+from .const import CONF_CAMERA_ZONE_IDS, DATA_COORDINATOR, DOMAIN
 from .coordinator import CrowShepherdCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,18 +33,21 @@ async def async_setup_entry(
     coordinator: CrowShepherdCoordinator = hass.data[DOMAIN][entry.entry_id][
         DATA_COORDINATOR
     ]
+    camera_zone_ids: set[int] = set(entry.options.get(CONF_CAMERA_ZONE_IDS, []))
     entities = [
         CrowShepherdCameraImage(coordinator, zone)
         for zone in coordinator.data.zones
+        if zone.is_camera or zone.id in camera_zone_ids
     ]
     async_add_entities(entities)
 
-    # Pre-populate entities with the most recent stored picture on startup.
-    # Zones with no pictures are skipped silently.
-    await asyncio.gather(
-        *(entity.async_fetch_snapshot(silent=True) for entity in entities),
-        return_exceptions=True,
-    )
+    if not entities:
+        _LOGGER.warning(
+            "No PIR camera image entities created. "
+            "If your panel has PIR cameras, go to Settings \u2192 Devices & Services "
+            "\u2192 Crow Shepherd \u2192 Configure and select the camera zones under "
+            "'PIR Camera Zones', then reload the integration."
+        )
 
     platform = async_get_current_platform()
     platform.async_register_entity_service(
@@ -90,6 +92,15 @@ class CrowShepherdCameraImage(
             manufacturer="Crow",
             model=panel.firmware_version or "Alarm Panel",
         )
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity is added to hass.
+
+        Calls super() first so CoordinatorEntity and ImageEntity both initialize
+        (including access_tokens), then silently fetches the latest stored picture.
+        """
+        await super().async_added_to_hass()
+        await self.async_fetch_snapshot(silent=True)
 
     @property
     def image_last_updated(self) -> datetime | None:

--- a/custom_components/crow_shepherd/manifest.json
+++ b/custom_components/crow_shepherd/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/tubalainen/crow_security/issues",
   "requirements": ["crow_security_ng>=0.2.1"],
-  "version": "0.2.3",
+  "version": "0.2.4",
   "integration_type": "hub"
 }

--- a/custom_components/crow_shepherd/strings.json
+++ b/custom_components/crow_shepherd/strings.json
@@ -44,11 +44,13 @@
         "description": "Adjust integration settings.",
         "data": {
           "scan_interval": "Update interval (seconds)",
-          "panel_code": "Panel User Code"
+          "panel_code": "Panel User Code",
+          "camera_zone_ids": "PIR Camera Zones"
         },
         "data_description": {
           "scan_interval": "How often to poll the Crow Cloud for updates (10–300 seconds).",
-          "panel_code": "The numeric user code used to arm and disarm the panel. Leave blank if not required."
+          "panel_code": "The numeric user code used to arm and disarm the panel. Leave blank if not required.",
+          "camera_zone_ids": "Select zones that are PIR cameras. An image entity will be created for each selected zone, pre-populated with the latest stored snapshot on startup."
         }
       }
     }

--- a/custom_components/crow_shepherd/translations/en.json
+++ b/custom_components/crow_shepherd/translations/en.json
@@ -44,11 +44,13 @@
         "description": "Adjust integration settings.",
         "data": {
           "scan_interval": "Update interval (seconds)",
-          "panel_code": "Panel User Code"
+          "panel_code": "Panel User Code",
+          "camera_zone_ids": "PIR Camera Zones"
         },
         "data_description": {
           "scan_interval": "How often to poll the Crow Cloud for updates (10–300 seconds).",
-          "panel_code": "The numeric user code used to arm and disarm the panel. Leave blank if not required."
+          "panel_code": "The numeric user code used to arm and disarm the panel. Leave blank if not required.",
+          "camera_zone_ids": "Select zones that are PIR cameras. An image entity will be created for each selected zone, pre-populated with the latest stored snapshot on startup."
         }
       }
     }


### PR DESCRIPTION
## Summary
- **Restore PIR Camera Zones selector** in Options flow — only selected zones get `image.*` entities, not every zone on the panel
- **Fix `access_tokens` crash**: moved startup snapshot fetch into `async_added_to_hass` so `ImageEntity` has fully initialized before `async_write_ha_state()` is called
- **Remove `OptionsFlow.__init__`**: incompatible with HA 2024.11+ where `config_entry` is a read-only base-class property — Options gear now opens without a 500 error
- **Fix `async_request_refresh` warning**: coroutine was never awaited in WebSocket message handler; now scheduled via `hass.async_create_task()`

## Test plan
- [ ] Options gear opens without a 500 error
- [ ] PIR Camera Zones selector shows all zones; select cam zones and save
- [ ] After reload, only selected zones have `image.*` entities
- [ ] On startup, camera entities are pre-populated with the latest stored picture
- [ ] No `access_tokens` AttributeError in the log
- [ ] No `async_request_refresh` RuntimeWarning in the log
- [ ] `crow_shepherd.fetch_camera_snapshot` action still works to refresh an entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)