### PR TITLE
fix: call ImageEntity.__init__(hass) to initialize access_tokens (v0.2.5)

### DIFF
--- a/custom_components/crow_shepherd/image.py
+++ b/custom_components/crow_shepherd/image.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
     ]
     camera_zone_ids: set[int] = set(entry.options.get(CONF_CAMERA_ZONE_IDS, []))
     entities = [
-        CrowShepherdCameraImage(coordinator, zone)
+        CrowShepherdCameraImage(hass, coordinator, zone)
         for zone in coordinator.data.zones
         if zone.is_camera or zone.id in camera_zone_ids
     ]
@@ -68,11 +68,13 @@ class CrowShepherdCameraImage(
 
     def __init__(
         self,
+        hass: HomeAssistant,
         coordinator: CrowShepherdCoordinator,
         zone: Zone,
     ) -> None:
         """Initialise entity."""
-        super().__init__(coordinator)
+        CoordinatorEntity.__init__(self, coordinator)
+        ImageEntity.__init__(self, hass)
         self._zone_id = zone.id
         self._attr_unique_id = f"{coordinator.hub.mac}_zone_{zone.id}_image"
         self._attr_name = f"{zone.name} Snapshot"

--- a/custom_components/crow_shepherd/manifest.json
+++ b/custom_components/crow_shepherd/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/tubalainen/crow_security/issues",
   "requirements": ["crow_security_ng>=0.2.1"],
-  "version": "0.2.4",
+  "version": "0.2.5",
   "integration_type": "hub"
 }


### PR DESCRIPTION
## Summary
- **Root cause**: `ImageEntity.__init__(hass)` is where `access_tokens` is created. The previous `super().__init__(coordinator)` only traversed the `CoordinatorEntity` chain — `ImageEntity.__init__` was never called because its `hass` parameter is incompatible with cooperative `super()`.
- **Fix**: explicitly call both parent `__init__` methods in `CrowShepherdCameraImage.__init__`:
  - `CoordinatorEntity.__init__(self, coordinator)` — sets up coordinator listener
  - `ImageEntity.__init__(self, hass)` — initializes `access_tokens`
- Accept `hass` as first argument and pass it from `async_setup_entry`

## Test plan
- [ ] Restart HA — no `access_tokens` AttributeError in log
- [ ] Camera image entities appear (Unavailable for zones with no stored pictures)
- [ ] Configure PIR Camera Zones in Options gear, reload — only selected zones get `image.*` entities
- [ ] Call `crow_shepherd.fetch_camera_snapshot` → entity updates with image

🤖 Generated with [Claude Code](https://claude.com/claude-code)