### PR TITLE
fix: add target definition to fetch_camera_snapshot service (v0.2.6)

### DIFF
--- a/custom_components/crow_shepherd/manifest.json
+++ b/custom_components/crow_shepherd/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/tubalainen/crow_security/issues",
   "requirements": ["crow_security_ng>=0.2.1"],
-  "version": "0.2.5",
+  "version": "0.2.6",
   "integration_type": "hub"
 }

--- a/custom_components/crow_shepherd/strings.json
+++ b/custom_components/crow_shepherd/strings.json
@@ -58,7 +58,15 @@
   "services": {
     "fetch_camera_snapshot": {
       "name": "Fetch camera snapshot",
-      "description": "Downloads the latest snapshot from a PIR camera zone and updates the image entity."
+      "description": "Downloads the latest snapshot from a PIR camera zone and updates the image entity.",
+      "target": {
+        "entity": [
+          {
+            "integration": "crow_shepherd",
+            "domain": "image"
+          }
+        ]
+      }
     },
     "bypass_zone": {
       "name": "Bypass Zone",

--- a/custom_components/crow_shepherd/translations/en.json
+++ b/custom_components/crow_shepherd/translations/en.json
@@ -58,7 +58,15 @@
   "services": {
     "fetch_camera_snapshot": {
       "name": "Fetch camera snapshot",
-      "description": "Downloads the latest snapshot from a PIR camera zone and updates the image entity."
+      "description": "Downloads the latest snapshot from a PIR camera zone and updates the image entity.",
+      "target": {
+        "entity": [
+          {
+            "integration": "crow_shepherd",
+            "domain": "image"
+          }
+        ]
+      }
     },
     "bypass_zone": {
       "name": "Bypass Zone",


### PR DESCRIPTION
## Summary
- The `fetch_camera_snapshot` service was missing a `target` field in `strings.json` and `translations/en.json`
- HA's Developer Tools → Actions showed "No targets" in the entity picker even though image entities existed
- Added `"target": {"entity": [{"integration": "crow_shepherd", "domain": "image"}]}` to the service description in both files so the UI correctly lists camera image entities as targets

## Test plan
- [ ] Restart HA (or reload integration)
- [ ] Go to Developer Tools → Actions → `crow_shepherd.fetch_camera_snapshot`
- [ ] Click "Add target" — the configured `image.*` entities should appear in the picker
- [ ] Select one and call the action — image entity should update with a fresh snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)