### PR TITLE
feat: trigger real camera capture on fetch_camera_snapshot action (v0.2.7)

### DIFF
--- a/custom_components/crow_shepherd/image.py
+++ b/custom_components/crow_shepherd/image.py
@@ -1,6 +1,7 @@
 """Image platform for Crow Shepherd PIR camera zones."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime
 from typing import Any
@@ -114,32 +115,77 @@ class CrowShepherdCameraImage(
         return self._image_bytes
 
     async def async_fetch_snapshot(self, *, silent: bool = False) -> None:
-        """Fetch the latest snapshot from the panel and store it.
+        """Fetch a snapshot from the panel and update the entity.
 
-        Called by the crow_shepherd.fetch_camera_snapshot action, and also
-        automatically on integration startup (with silent=True).
+        silent=True (startup): retrieve the latest stored picture — no new capture.
+        silent=False (user action): trigger a new capture, then poll until it appears.
         """
+        panel = self.coordinator.hub.panel
+        session = self.coordinator.hub.session
+
+        if not silent:
+            # ── Explicit user action: trigger a new capture ───────────────
+            # Record the current newest picture ID so we know when a new one arrives.
+            try:
+                existing = await panel.get_zone_pictures(self._zone_id, page_size=1)
+                prev_id = existing[0].id if existing else None
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.error(
+                    "Zone %s: could not check existing pictures: %s",
+                    self._zone_id, err,
+                )
+                return
+
+            try:
+                await panel.capture_picture(self._zone_id)
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.error(
+                    "Zone %s: could not trigger capture: %s",
+                    self._zone_id, err,
+                )
+                return
+
+            # Poll up to ~30 s (10 × 3 s) for the new picture to appear
+            pic = None
+            for _ in range(10):
+                await asyncio.sleep(3)
+                try:
+                    pics = await panel.get_zone_pictures(self._zone_id, page_size=1)
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.error("Zone %s: poll error: %s", self._zone_id, err)
+                    return
+                if pics and pics[0].id != prev_id:
+                    pic = pics[0]
+                    break
+
+            if pic is None:
+                _LOGGER.warning(
+                    "Zone %s: timed out waiting for new picture after capture",
+                    self._zone_id,
+                )
+                return
+
+        else:
+            # ── Silent startup fetch: retrieve the latest stored picture ──
+            try:
+                pics = await panel.get_zone_pictures(self._zone_id, page_size=1)
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.error(
+                    "Zone %s: could not list pictures: %s",
+                    self._zone_id, err,
+                )
+                return
+            if not pics:
+                return  # no pictures stored yet — silent, no warning
+            pic = pics[0]
+
+        # ── Download and store the picture ────────────────────────────────
         try:
-            pics = await self.coordinator.hub.panel.get_zone_pictures(self._zone_id)
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.error("Zone %s: could not list pictures: %s", self._zone_id, err)
-            return
-
-        if not pics:
-            if not silent:
-                _LOGGER.warning("Zone %s: no pictures available yet", self._zone_id)
-            return
-
-        pic = pics[-1]
-
-        try:
-            self._image_bytes = await self.coordinator.hub.session.get_picture_bytes(pic)
+            self._image_bytes = await session.get_picture_bytes(pic)
         except Exception as err:  # noqa: BLE001
             _LOGGER.error(
                 "Zone %s: could not download picture %s: %s",
-                self._zone_id,
-                pic.id,
-                err,
+                self._zone_id, pic.id, err,
             )
             return
 

--- a/custom_components/crow_shepherd/manifest.json
+++ b/custom_components/crow_shepherd/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/tubalainen/crow_security/issues",
   "requirements": ["crow_security_ng>=0.2.1"],
-  "version": "0.2.6",
+  "version": "0.2.7",
   "integration_type": "hub"
 }


### PR DESCRIPTION
## Summary
- `fetch_camera_snapshot` previously only fetched a cached/stored picture — it never triggered a new capture
- Now calls `panel.capture_picture(zone_id)` (POST) to request a fresh snapshot from the camera
- Polls `get_zone_pictures` every 3 s until the new picture appears (up to ~30 s), then downloads and updates the entity
- Startup auto-fetch (`silent=True`) is unchanged — still retrieves the latest stored picture silently without triggering a new capture

## Behaviour
| Path | Action |
|------|--------|
| `fetch_camera_snapshot` action | `capture_picture()` → poll for new picture ID → download → update entity |
| Integration startup | `get_zone_pictures()` → download latest stored → update entity (no capture) |

## Test plan
- [ ] Call `crow_shepherd.fetch_camera_snapshot` — entity should update with a fresh image within ~30 s
- [ ] Restart HA — entity pre-populates with latest stored picture, no log warnings for zones with no pictures
- [ ] If camera is offline/fails — log shows "Zone N: timed out waiting for new picture after capture"

🤖 Generated with [Claude Code](https://claude.com/claude-code)